### PR TITLE
Permit the player to triple jump under 80 x velocity if the player has the wing powerup

### DIFF
--- a/scenes/actors/mario/states/Jump.gd
+++ b/scenes/actors/mario/states/Jump.gd
@@ -39,7 +39,7 @@ func _start(delta):
 	if ledge_buffer > 0:
 		if dive_buffer > 0:
 			character.current_jump = 0
-		if character.current_jump == 2 and abs(character.velocity.x) < 80:
+		if character.current_jump == 2 and (not (character.powerup is WingPowerup) and abs(character.velocity.x) < 80):
 			character.current_jump = 1
 		if character.current_jump != 2 and character.last_state == character.get_state_node("SpinningState"):
 			character.set_state_by_name("SpinningState", delta)


### PR DESCRIPTION
When I play Super Mario 64, I'm able to triple jump while not moving whenever I have the wing cap. This behaviour didn't exist in Super Mario 127 which threw me off. As a result, I decided to add this functionality in.