### PR TITLE
Area Transition bug fix

### DIFF
--- a/scenes/actors/objects/area_transition/area_transition.gd
+++ b/scenes/actors/objects/area_transition/area_transition.gd
@@ -216,7 +216,7 @@ func pipe_exit_anim_finished(character : Character):
 	Singleton.CurrentLevelData.level_data.vars.transition_character_data = []
 	Singleton.CurrentLevelData.level_data.vars.transition_character_data_2 = []
 	entering = false
-	#Why was the line bellow even commented????
+	#Why was the line below even commented???? (it was 'bellow' before)
 	character.toggle_movement(true)
 	# undo collision changes 
 	stored_characters[character.player_id] = null

--- a/scenes/actors/objects/area_transition/area_transition.gd
+++ b/scenes/actors/objects/area_transition/area_transition.gd
@@ -216,7 +216,8 @@ func pipe_exit_anim_finished(character : Character):
 	Singleton.CurrentLevelData.level_data.vars.transition_character_data = []
 	Singleton.CurrentLevelData.level_data.vars.transition_character_data_2 = []
 	entering = false
-	#character.toggle_movement(true)
+	#Why was the line bellow even commented????
+	character.toggle_movement(true)
 	# undo collision changes 
 	stored_characters[character.player_id] = null
 	area2d.connect("body_exited", self, "exit_remote_teleport")


### PR DESCRIPTION
If you connect a door/pipe with an area transition and set them to remote you'll get softlocked when trying to enter the door/pipe.