### PR TITLE
enemy tweaks

### DIFF
--- a/scenes/actors/objects/cheep_cheep/cheep_cheep.tscn
+++ b/scenes/actors/objects/cheep_cheep/cheep_cheep.tscn
@@ -119,7 +119,7 @@ tracks/2/keys = {
 "times": PoolRealArray( 0, 0.1, 0.11, 0.2, 0.4 ),
 "transitions": PoolRealArray( 1, 8.95777e-12, 1, 2.82843, 1 ),
 "update": 0,
-"values": [ Vector2( 1, 1 ), Vector2( 1, 0.5 ), Vector2( 1, 1 ), Vector2( 1, 0.1 ), Vector2( 0.1, 1.5 ) ]
+"values": [ Vector2( 1, 1 ), Vector2( 1, 0.5 ), Vector2( 1, 1 ), Vector2( 1, 0.1 ), Vector2( 0, 1.5 ) ]
 }
 tracks/3/type = "value"
 tracks/3/path = NodePath("..:top_point")

--- a/scenes/actors/objects/nipper_plant/nipper_plant.gd
+++ b/scenes/actors/objects/nipper_plant/nipper_plant.gd
@@ -25,7 +25,7 @@ var hit: = false
 var bouncy_fire := false
 
 var gravity: = 0.0
-var gravit_scale: = 1.0
+var gravit_scale: = 2.0
 var wander_timer: = 0.0
 var wander_pause_timer: = 1.0
 var fire_pause: = 0.0
@@ -276,6 +276,6 @@ func spawn_fireball():
 	object.properties.append(0)
 	object.properties.append(true)
 	object.properties.append(true)
-	object.properties.append(calculate_fireball_velocity(body.global_position - Vector2(0, 8), character_position, gravity*gravit_scale))
+	object.properties.append(calculate_fireball_velocity(body.global_position - Vector2(0, 8), character_position, gravity))
 	object.properties.append(fire == 2)
 	get_parent().create_object(object, false)

--- a/scenes/actors/objects/skeleton_goonie/skeleton_goonie.gd
+++ b/scenes/actors/objects/skeleton_goonie/skeleton_goonie.gd
@@ -26,7 +26,7 @@ var bomb_collision_mask: = 0
 var wingless_dir: = 1
 
 var gravity: = 0.0
-var gravity_scale: = 1.0
+var gravity_scale: = 2
 var wingless_spd: = 120.0
 var inv_timer: = 0.0
 var delete_timer: = 0.0
@@ -187,7 +187,7 @@ func drop_bomb():
 	if (bomb_body.get_parent() != wing_body or dropped_bomb):
 		return
 	
-	bomb_velocity.y = gravity * (gravity_scale * 16)
+	bomb_velocity.y = gravity * (gravity_scale * 8)
 	bomb_body.collision_mask = bomb_collision_mask
 	dropped_bomb = true
 


### PR DESCRIPTION
- nippers, skele-goonies, and rexes now have gravity applied consistently with other enemies
- tweaks on the knockback rexes take from spins
- fixed cheep cheep death animation not fully shrinking the sprite when finishing