### PR TITLE
fixed area setting duplication

### DIFF
--- a/level/Area.gd
+++ b/level/Area.gd
@@ -15,5 +15,18 @@ func _init():
 	pass
 
 func duplicate(base_area):
+	settings = duplicate_settings(base_area.settings)
 	objects = base_area.objects.duplicate(true)
 	tile_chunks = base_area.tile_chunks.duplicate(true)
+
+func duplicate_settings(base_settings):
+	var new_settings = LevelAreaSettings.new()
+	new_settings.sky = base_settings.sky
+	new_settings.background = base_settings.background
+	new_settings.background_palette = base_settings.background_palette
+	new_settings.music = base_settings.music
+	new_settings.bounds = base_settings.bounds
+	new_settings.gravity = base_settings.gravity
+	new_settings.timer = base_settings.timer
+	
+	return new_settings

--- a/scenes/actors/objects/crystal_tap/crystal_tap.gd
+++ b/scenes/actors/objects/crystal_tap/crystal_tap.gd
@@ -4,34 +4,49 @@ onready var use_area = $UseArea
 onready var anim_player = $AnimationPlayer
 onready var offset_line = $Line2D
 
+var auto_activate_time := 0.0
+
 var tag := "default"
 var auto_activate := false
 var move_speed := 1.0
 var offset := 0.0
 var horizontal := false
+var cycle_timer := 0.0
+var cycle_offset := 0.0
 
 func _set_properties():
-	savable_properties = ["tag", "auto_activate", "move_speed", "offset", "horizontal"]
-	editable_properties = ["tag", "auto_activate", "move_speed", "offset", "horizontal"]
+	savable_properties = ["tag", "auto_activate", "move_speed", "offset", "horizontal", "cycle_timer", "cycle_offset"]
+	editable_properties = ["tag", "auto_activate", "move_speed", "offset", "horizontal", "cycle_timer", "cycle_offset"]
 
 func _set_property_values():
 	set_property("tag", tag)
-	set_property("auto_activate", auto_activate)
+	set_property("auto_activate", auto_activate, true, "Activate on Start")
 	set_property("move_speed", move_speed)
 	set_property("offset", offset)
 	set_property("horizontal", horizontal)
+	set_property("cycle_timer", cycle_timer)
+	set_property("cycle_offset", cycle_offset)
 
 func _ready():
+	get_parent().connect("objects_ready", self, "ready_synced")
 	connect("property_changed", self, "_on_property_changed")
 	if enabled:
 		var _connect = use_area.connect("body_entered", self, "set_liquid_level")
 	yield(get_tree(), "physics_frame")
 	if mode != 1:
 		offset_line.visible = false
-		if auto_activate:
-			set_liquid_level(null)
+
 	else:
 		offset_line.visible = true
+	
+
+func ready_synced():
+	if mode != 1:
+		if auto_activate:
+			set_liquid_level(null)
+		
+		var timer = get_tree().create_timer(cycle_offset+cycle_timer, false)
+		timer.connect("timeout", self, "autoset_liquid_level")
 
 func _on_property_changed(key, value):
 	
@@ -44,7 +59,7 @@ func _on_property_changed(key, value):
 		
 	if "\n" in tag:
 		tag = tag.replace("\n", "")
-	
+
 func set_liquid_level(body):
 	if body != null and visible:
 		anim_player.play("touch")
@@ -64,3 +79,9 @@ func set_liquid_level(body):
 			
 			#found_liquid[1].save_pos = Vector2(found_liquid[1].global_position.x + (offset if horizontal else 0), global_position.y + (0 if horizontal else offset)) 
 			found_liquid[1].horizontal = horizontal
+
+func autoset_liquid_level():
+	set_liquid_level(0)
+	
+	var timer = get_tree().create_timer(cycle_timer, false)
+	timer.connect("timeout", self, "autoset_liquid_level")

--- a/scenes/actors/objects/npc_base/animation_handler.gd
+++ b/scenes/actors/objects/npc_base/animation_handler.gd
@@ -27,20 +27,20 @@ func _process(delta):
 	head.rotation_degrees = 0
 	
 	if head_transforms:
-    if head_anim == "confused":
-      head.rotation_degrees = 10
-      head.offset = Vector2(1, 0)
+		if head_anim == "confused":
+			head.rotation_degrees = 10
+			head.offset = Vector2(1, 0)
 
-    if head_anim == "raging":
-      head.modulate = lerp(head.modulate, Color.red, delta)
-      head.offset = Vector2(
-        rand_range(-1.0, 1.0)*raging_scale,
-        rand_range(0, 2.0)*raging_scale
-      )
-    else:
-      head.modulate = lerp(head.modulate, Color.white, delta * 4)
+		if head_anim == "raging":
+			head.modulate = lerp(head.modulate, Color.red, delta)
+			head.offset = Vector2(
+				rand_range(-1.0, 1.0)*raging_scale,
+				rand_range(0, 2.0)*raging_scale
+			)
+		else:
+			head.modulate = lerp(head.modulate, Color.white, delta * 4)
 
-	
+		
 	if head_anim in expression_offsets:
 		head.offset = expression_offsets[head_anim]
 

--- a/scenes/actors/objects/red_bob_omb/red_bob_omb.gd
+++ b/scenes/actors/objects/red_bob_omb/red_bob_omb.gd
@@ -12,8 +12,8 @@ var rainbow: bool
 
 
 func _set_properties():
-	savable_properties = ["curve", "custom_path", "move_type", "walk_speed", "physics_enabled", "idle_expression", "idle_action", "speaking_expression", "speaking_action", "path_reference", "dialogue_link", "color", "rainbow"]
-	editable_properties = ["idle_expression", "idle_action", "speaking_expression", "speaking_action", "dialogue_link", "custom_path", "walk_speed", "move_type", "physics_enabled", "path_reference", "color", "rainbow"]
+	savable_properties = ["curve", "custom_path", "move_type", "walk_speed", "physics_enabled", "idle_expression", "idle_action", "speaking_expression", "speaking_action", "path_reference", "tag_link", "color", "rainbow"]
+	editable_properties = ["idle_expression", "idle_action", "speaking_expression", "speaking_action", "tag_link", "custom_path", "walk_speed", "move_type", "physics_enabled", "path_reference", "color", "rainbow"]
 
 
 func _set_property_values():

--- a/scenes/actors/objects/rex/rex.tscn
+++ b/scenes/actors/objects/rex/rex.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=39 format=2]
+[gd_scene load_steps=40 format=2]
 
 [ext_resource path="res://scenes/actors/objects/rex/rex.tres" type="SpriteFrames" id=1]
 [ext_resource path="res://scenes/actors/objects/rex/rex.gd" type="Script" id=2]
@@ -116,6 +116,9 @@ extents = Vector2( 208.896, 69.015 )
 
 [sub_resource type="RectangleShape2D" id=15]
 extents = Vector2( 30, 32 )
+
+[sub_resource type="RectangleShape2D" id=32]
+extents = Vector2( 11, 8 )
 
 [sub_resource type="Animation" id=7]
 length = 0.001
@@ -493,6 +496,16 @@ priority = 1.0
 
 [node name="Collision" type="CollisionShape2D" parent="Rex/CollisionLayerArea"]
 shape = SubResource( 15 )
+
+[node name="WaterDetector" type="Area2D" parent="Rex"]
+visible = false
+position = Vector2( 0, -7 )
+collision_layer = 0
+collision_mask = 128
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Rex/WaterDetector"]
+position = Vector2( 0, 8 )
+shape = SubResource( 32 )
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="Rex"]
 anims/RESET = SubResource( 7 )

--- a/scenes/editor/AreaPanel.gd
+++ b/scenes/editor/AreaPanel.gd
@@ -77,7 +77,6 @@ func duplicate_area():
 		var area = LevelArea.new()
 		var dup = Singleton.CurrentLevelData.level_data.areas[id]
 		area.duplicate(dup)
-		area.settings = Singleton.CurrentLevelData.level_data.areas[id].settings
 		Singleton.CurrentLevelData.level_data.areas.append(area)
 		get_parent().get_parent().get_parent().reload_areas()
 	

--- a/scenes/editor/property_type_scenes/PoolStringArray/base/DialogueInput.tscn
+++ b/scenes/editor/property_type_scenes/PoolStringArray/base/DialogueInput.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=22 format=2]
+[gd_scene load_steps=23 format=2]
 
 [ext_resource path="res://scenes/editor/sounds/click2.wav" type="AudioStream" id=1]
 [ext_resource path="res://scenes/editor/sounds/hover.wav" type="AudioStream" id=2]
@@ -12,6 +12,7 @@
 [ext_resource path="res://assets/styles/ButtonStyleDisabled.tres" type="StyleBox" id=10]
 [ext_resource path="res://scenes/actors/objects/toad/body_preview.png" type="Texture" id=11]
 [ext_resource path="res://scenes/actors/objects/toad/head_preview.png" type="Texture" id=12]
+[ext_resource path="res://scenes/editor/property_type_scenes/PoolStringArray/base/facing_dir.gd" type="Script" id=13]
 
 [sub_resource type="DynamicFont" id=1]
 size = 56
@@ -71,7 +72,7 @@ font_data = ExtResource( 7 )
 [node name="DialogueInput" type="NinePatchRect"]
 margin_left = 165.0
 margin_top = 110.0
-margin_right = 1218.0
+margin_right = 1365.0
 margin_bottom = 612.0
 rect_scale = Vector2( 0.4, 0.4 )
 mouse_filter = 0
@@ -94,17 +95,15 @@ bbcode_text = "Text"
 text = "Text"
 
 [node name="CloseButton" type="TextureButton" parent="."]
-margin_left = 888.65
-margin_top = 12.953
-margin_right = 1043.65
-margin_bottom = 93.953
+anchor_left = 1.0
+anchor_right = 1.0
+margin_left = -170.0
+margin_top = 14.0
+margin_bottom = 81.0
 rect_scale = Vector2( 0.95, 0.95 )
 texture_normal = ExtResource( 5 )
 texture_pressed = ExtResource( 5 )
 texture_hover = ExtResource( 4 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="HoverSound" type="AudioStreamPlayer" parent="CloseButton"]
 stream = ExtResource( 2 )
@@ -125,9 +124,10 @@ margin_bottom = 498.0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="Contents"]
 margin_left = 18.0
-margin_top = 148.0
-margin_right = 1008.0
-margin_bottom = 228.0
+margin_top = 158.0
+margin_right = 1145.0
+margin_bottom = 238.0
+grow_horizontal = 2
 
 [node name="Back" type="Button" parent="Contents/HBoxContainer"]
 margin_right = 96.0
@@ -159,13 +159,13 @@ text = "Next"
 
 [node name="Padding" type="Control" parent="Contents/HBoxContainer"]
 margin_left = 200.0
-margin_right = 232.0
+margin_right = 217.0
 margin_bottom = 80.0
 size_flags_horizontal = 3
 
 [node name="RemoteTag" type="LineEdit" parent="Contents/HBoxContainer"]
-margin_left = 236.0
-margin_right = 460.0
+margin_left = 221.0
+margin_right = 445.0
 margin_bottom = 80.0
 rect_min_size = Vector2( 224, 0 )
 custom_colors/font_color_selected = Color( 0, 0, 0, 1 )
@@ -176,14 +176,14 @@ align = 1
 placeholder_text = "Remote Tag"
 
 [node name="Padding3" type="Control" parent="Contents/HBoxContainer"]
-margin_left = 464.0
-margin_right = 496.0
+margin_left = 449.0
+margin_right = 467.0
 margin_bottom = 80.0
 size_flags_horizontal = 3
 
 [node name="Expression" type="Button" parent="Contents/HBoxContainer"]
-margin_left = 500.0
-margin_right = 580.0
+margin_left = 471.0
+margin_right = 551.0
 margin_bottom = 80.0
 rect_min_size = Vector2( 80, 0 )
 focus_mode = 0
@@ -201,16 +201,16 @@ region_enabled = true
 region_rect = Rect2( 0, 0, 32, 32 )
 
 [node name="IndexDisplay" type="Label" parent="Contents/HBoxContainer"]
-margin_left = 584.0
+margin_left = 555.0
 margin_top = 22.0
-margin_right = 653.0
+margin_right = 624.0
 margin_bottom = 58.0
 custom_fonts/font = SubResource( 18 )
 text = "0/10"
 
 [node name="Action" type="Button" parent="Contents/HBoxContainer"]
-margin_left = 657.0
-margin_right = 737.0
+margin_left = 628.0
+margin_right = 708.0
 margin_bottom = 80.0
 rect_min_size = Vector2( 80, 0 )
 focus_mode = 0
@@ -228,14 +228,46 @@ region_enabled = true
 region_rect = Rect2( 0, 0, 32, 32 )
 
 [node name="Padding2" type="Control" parent="Contents/HBoxContainer"]
-margin_left = 741.0
-margin_right = 773.0
+margin_left = 712.0
+margin_right = 730.0
+margin_bottom = 80.0
+rect_pivot_offset = Vector2( -899.904, -37 )
+size_flags_horizontal = 3
+
+[node name="FacingDir" type="Button" parent="Contents/HBoxContainer"]
+margin_left = 734.0
+margin_right = 889.0
+margin_bottom = 80.0
+rect_min_size = Vector2( 96, 0 )
+focus_mode = 0
+custom_fonts/font = SubResource( 17 )
+custom_styles/hover = SubResource( 14 )
+custom_styles/pressed = SubResource( 15 )
+custom_styles/disabled = ExtResource( 10 )
+custom_styles/normal = SubResource( 15 )
+enabled_focus_mode = 0
+text = "Face Left"
+script = ExtResource( 13 )
+
+[node name="HoverSound" type="AudioStreamPlayer" parent="Contents/HBoxContainer/FacingDir"]
+stream = ExtResource( 2 )
+volume_db = -10.0
+bus = "Sounds"
+
+[node name="ClickSound" type="AudioStreamPlayer" parent="Contents/HBoxContainer/FacingDir"]
+stream = ExtResource( 1 )
+volume_db = -10.0
+bus = "Sounds"
+
+[node name="Padding4" type="Control" parent="Contents/HBoxContainer"]
+margin_left = 893.0
+margin_right = 911.0
 margin_bottom = 80.0
 size_flags_horizontal = 3
 
 [node name="Add" type="Button" parent="Contents/HBoxContainer"]
-margin_left = 777.0
-margin_right = 857.0
+margin_left = 915.0
+margin_right = 995.0
 margin_bottom = 80.0
 rect_min_size = Vector2( 80, 0 )
 focus_mode = 0
@@ -248,8 +280,8 @@ enabled_focus_mode = 0
 text = "Add"
 
 [node name="Remove" type="Button" parent="Contents/HBoxContainer"]
-margin_left = 861.0
-margin_right = 989.0
+margin_left = 999.0
+margin_right = 1127.0
 margin_bottom = 80.0
 rect_min_size = Vector2( 128, 0 )
 focus_mode = 0
@@ -263,8 +295,8 @@ text = "Remove"
 
 [node name="TextEdit" type="TextEdit" parent="Contents"]
 margin_left = 18.0
-margin_top = 17.0
-margin_right = 1008.0
+margin_top = 18.0
+margin_right = 1142.0
 margin_bottom = 148.0
 custom_colors/font_color_selected = Color( 0, 0, 0, 1 )
 custom_colors/font_color = Color( 0.188235, 0.258824, 0.494118, 1 )
@@ -276,10 +308,10 @@ v_scroll_speed = 0.0
 wrap_enabled = true
 
 [node name="SaveButton" type="Button" parent="Contents"]
-margin_left = 534.307
-margin_top = 261.792
-margin_right = 934.307
-margin_bottom = 351.792
+margin_left = 668.0
+margin_top = 261.0
+margin_right = 1052.0
+margin_bottom = 351.0
 custom_fonts/font = SubResource( 16 )
 custom_styles/hover = SubResource( 14 )
 custom_styles/pressed = SubResource( 15 )
@@ -300,10 +332,10 @@ volume_db = -10.0
 bus = "Sounds"
 
 [node name="CancelButton" type="Button" parent="Contents"]
-margin_left = 82.2546
-margin_top = 261.792
-margin_right = 482.255
-margin_bottom = 351.792
+margin_left = 96.0
+margin_top = 261.0
+margin_right = 480.0
+margin_bottom = 352.0
 custom_fonts/font = SubResource( 16 )
 custom_styles/hover = SubResource( 14 )
 custom_styles/pressed = SubResource( 15 )
@@ -329,11 +361,10 @@ margin_bottom = 12.0
 
 [node name="Tween" type="Tween" parent="."]
 
-[connection signal="pressed" from="Contents/HBoxContainer/Back" to="Contents/SaveButton" method="change_page" flags=3 binds= [ -1 ]]
 [connection signal="pressed" from="Contents/HBoxContainer/Back" to="Contents/SaveButton" method="save_page"]
-[connection signal="pressed" from="Contents/HBoxContainer/Next" to="Contents/SaveButton" method="change_page" flags=3 binds= [ 1 ]]
+[connection signal="pressed" from="Contents/HBoxContainer/Back" to="Contents/SaveButton" method="change_page" binds= [ -1 ]]
 [connection signal="pressed" from="Contents/HBoxContainer/Next" to="Contents/SaveButton" method="save_page"]
-[connection signal="focus_exited" from="Contents/HBoxContainer/RemoteTag" to="Contents/SaveButton" method="save_page"]
+[connection signal="pressed" from="Contents/HBoxContainer/Next" to="Contents/SaveButton" method="change_page" binds= [ 1 ]]
 [connection signal="pressed" from="Contents/HBoxContainer/Expression" to="Contents/SaveButton" method="cycle_expression"]
 [connection signal="pressed" from="Contents/HBoxContainer/Action" to="Contents/SaveButton" method="cycle_action"]
 [connection signal="pressed" from="Contents/HBoxContainer/Add" to="Contents/SaveButton" method="add_page"]

--- a/scenes/editor/property_type_scenes/PoolStringArray/base/DialogueSaveButton.gd
+++ b/scenes/editor/property_type_scenes/PoolStringArray/base/DialogueSaveButton.gd
@@ -12,6 +12,7 @@ var action: int = 0
 onready var back_button = $"../HBoxContainer/Back"
 onready var next_button = $"../HBoxContainer/Next"
 onready var remote_tag = $"../HBoxContainer/RemoteTag"
+onready var facing_dir = $"../HBoxContainer/FacingDir"
 onready var expression_sprite = $"../HBoxContainer/Expression/Sprite"
 onready var action_sprite = $"../HBoxContainer/Action/Sprite"
 onready var index_display = $"../HBoxContainer/IndexDisplay"

--- a/scenes/editor/property_type_scenes/PoolStringArray/base/facing_dir.gd
+++ b/scenes/editor/property_type_scenes/PoolStringArray/base/facing_dir.gd
@@ -1,0 +1,47 @@
+extends Button
+
+onready var hover_sound = $HoverSound
+onready var click_sound = $ClickSound
+
+var limits := Vector2(0, 2)
+var options := {
+	0: "Face Left",
+	1: "Face Right",
+	2: "Flip",
+}
+
+var value = 1
+var last_hovered = false
+
+func _ready():
+	var _connect = connect("pressed", self, "pressed")
+	if options != null:
+		var text: String = options[value]
+		if typeof(text) == TYPE_STRING:
+			text = text.capitalize()
+		text = text
+
+func pressed():
+	click_sound.play()
+	set_value(value+1)
+
+func set_value(_value: int):
+	value = _value
+	value = wrapi(value, limits.x, limits.y)
+	# Does object have a name for the value?
+	if options != null:
+		var text: String = options[value]
+		if typeof(text) == TYPE_STRING:
+			text = text.capitalize()
+		text = options[value]
+	else:
+		# Default to value otherwise
+		text = str(value)
+
+func get_value() -> int:
+	return value
+
+func _process(_delta):
+	if is_hovered() and !last_hovered:
+		hover_sound.play()	
+	last_hovered = is_hovered()

--- a/scenes/player/ui_new/collectibles/shine_shards.gd
+++ b/scenes/player/ui_new/collectibles/shine_shards.gd
@@ -9,13 +9,11 @@ onready var fill: TextureProgress = $Resizable/Fill
 var max_shards: int
 
 func _ready():
-	# and this time, we have to wait for all the shine shard objects to load
-	# (kind of a bad solution imo)
-	for i in range(5):
-		yield(get_tree(), "physics_frame")
-#	var objects = get_node("/root").get_node("Player").get_shared_node().get_node("Objects")
-#	yield(objects, "finished_loading")
+	var objects = get_node("/root").get_node("Player").get_shared_node().get_node("Objects")
+	objects.connect("objects_ready", self, "delayed_ready")
 	
+
+func delayed_ready():
 	var variables: LevelVars = Singleton.CurrentLevelData.level_data.vars
 	max_shards = variables.max_shine_shards
 	fill.max_value = max_shards
@@ -29,7 +27,7 @@ func _ready():
 				Singleton.CurrentLevelData.area][0]
 			)
 		
-		label.text = str(max_shards)
+		label.text = str(shard_amount)
 		fill.value = shard_amount
 
 

--- a/scenes/shared/objects.gd
+++ b/scenes/shared/objects.gd
@@ -2,7 +2,7 @@ extends Node
 
 #TODO: Optimize
 
-signal finished_loading
+signal objects_ready
 
 var level_data : LevelData
 var level_area : LevelArea
@@ -10,17 +10,15 @@ var level_area : LevelArea
 var object_cache = []
 
 var object_index = 0
-var object_count = 0
 
 func load_in(loaded_level_data : LevelData, loaded_level_area : LevelArea):
 	object_index = 0
-	object_count = get_child_count()
+	
 	level_data = loaded_level_data
 	level_area = loaded_level_area
 	
 	for object in loaded_level_area.objects:
 		create_object(object, false)
-		object_index += 1
 		
 func set_property(object_node : GameObject, property, value):
 	object_node.set_property(property, value, true)
@@ -30,6 +28,7 @@ func create_object(object, add_to_data):
 	var object_scene = Singleton.CurrentLevelData.get_cached_object(object.type_id)
 	if object_scene != null:
 		var object_node = object_scene.instance()
+		object_node.connect("ready", self, "object_ready")
 		object_node.mode = mode
 		object_node.level_data = level_data
 		object_node.level_area = level_area
@@ -75,7 +74,10 @@ func move_object_to_front(object_node):
 	level_area.objects.append(level_object)
 	move_child(object_node, get_child_count()-1)
 
-func _process(delta):
-	if object_index == object_count-1:
-		emit_signal("finished_loading")
-		print("objects loaded")
+func object_ready():
+	object_index += 1
+	var object_count = level_area.objects.size()
+	
+	if object_index == object_count:
+		emit_signal("objects_ready")
+		print("Objects are all loaded!")


### PR DESCRIPTION
- area settings no longer duplicate, (hopefully) fully eliminating the area dupe bug
- added a signal to detect when all objects are loaded
- crystal taps can now be timed to activate (similar to fire pillars and bullet bills)
- fixed shine shard UI not updating correctly upon entering a new area
- rex now interacts with water appropriately
- started on allowing the facing direction of an NPC to be changed per dialogue page