### PR TITLE
a few bugfixes and new additions

### DIFF
--- a/classes/teleport_object.gd
+++ b/classes/teleport_object.gd
@@ -83,7 +83,7 @@ func get_character_screen_position(character : Character) -> Vector2:
 	# Return relative screen position
 	return character.global_position - camera_pos + Vector2(384, 216)
 
-func change_areas(entering_character : Character, entering):
+func change_areas(entering_character : Character, entering, force_fadeout):
 	#TODO: REMOVE UPWARD CALLS ASAP
 	var character = get_tree().get_current_scene().get_node(get_tree().get_current_scene().character) #Holy crap this is bad
 	var character2
@@ -168,12 +168,13 @@ func exit_local_teleport():
 func exit_remote_teleport():
 	pass
 
-func _start_local_transition(character : Character, entering, force_fadeout := false) -> void:
+func _start_local_transition(character : Character, entering, working_force_fadeout := false) -> void:
 	var local_pair = find_local_pair()
 	if entering:
-		character.force_warp_fadeout = force_fadeout
+		working_force_fadeout = working_force_fadeout if teleportation_mode == false else true
+		character.force_warp_fadeout = working_force_fadeout
 		character.set_collision(false)
-		if global_position.distance_to(local_pair.global_position) <= 800 and !force_fadeout:
+		if global_position.distance_to(local_pair.global_position) <= 800 and !working_force_fadeout:
 			
 			var tween = Tween.new()
 			add_child(tween)

--- a/classes/teleport_object.gd
+++ b/classes/teleport_object.gd
@@ -18,6 +18,7 @@ var object_type := "unknown"
 var destination_tag := "default_teleporter"
 var tp_pair : TeleportObject
 var instant : bool = false
+var force_fadeout := false
 var timer_manager
 
 ## For older levels only
@@ -50,7 +51,7 @@ func local_tp(entering_character : Character, entering):
 			entering_character.global_position = tp_pair.global_position
 			entering_character.reset_physics_interpolation()
 			
-			if tp_pair.object_type != "area_transition" or global_position.distance_to(tp_pair.global_position) > 800:
+			if tp_pair.object_type != "area_transition" or global_position.distance_to(tp_pair.global_position) > 800 or force_fadeout:
 				entering_character.camera.skip_to_player = true
 				entering_character.camera.global_position = entering_character.global_position
 			entering_character.sprite.modulate = Color(0, 0, 0, 0)
@@ -167,11 +168,12 @@ func exit_local_teleport():
 func exit_remote_teleport():
 	pass
 
-func _start_local_transition(character : Character, entering) -> void:
+func _start_local_transition(character : Character, entering, force_fadeout := false) -> void:
 	var local_pair = find_local_pair()
 	if entering:
+		character.force_warp_fadeout = force_fadeout
 		character.set_collision(false)
-		if global_position.distance_to(local_pair.global_position) <= 800:
+		if global_position.distance_to(local_pair.global_position) <= 800 and !force_fadeout:
 			
 			var tween = Tween.new()
 			add_child(tween)
@@ -193,7 +195,7 @@ func _start_local_transition(character : Character, entering) -> void:
 			Singleton.SceneTransitions.do_transition_animation(Singleton.SceneTransitions.cutout_circle, Singleton.SceneTransitions.DEFAULT_TRANSITION_TIME, Singleton.SceneTransitions.TRANSITION_SCALE_UNCOVER, Singleton.SceneTransitions.TRANSITION_SCALE_COVERED, -1, -1, false, false)
 	else:
 		
-		if global_position.distance_to(local_pair.global_position) > 800:
+		if global_position.distance_to(local_pair.global_position) > 800 or character.force_warp_fadeout:
 			# sets the transition center to Mario's position
 			Singleton.SceneTransitions.canvas_mask.global_position = get_character_screen_position(character)
 			# this starts an inner scene transition, then connects a function (one shot) to start as it finishes

--- a/scenes/actors/mario/mario.gd
+++ b/scenes/actors/mario/mario.gd
@@ -97,6 +97,7 @@ onready var spotlight : Light2D = $Spotlight
 export var cutout_death : StreamTexture
 export var cutout_circle : StreamTexture
 export var cutout_shine : StreamTexture
+var force_warp_fadeout : bool = false
 
 # Basic Physics
 export var initial_position := Vector2(0, 0)

--- a/scenes/actors/mode_switcher/mode_switcher_button.gd
+++ b/scenes/actors/mode_switcher/mode_switcher_button.gd
@@ -73,7 +73,7 @@ func change_visuals(new_scene_mode : int) -> void:
 func switch() -> void:
 	if get_parent().layer != 99 and !switching_disabled and !get_tree().paused and !Singleton.SceneTransitions.transitioning:
 		Singleton.Music.reset_music()
-		Singleton.Music.stop_temporary_music()
+		Singleton.Music.stop_temporary_music(1, 1)
 
 		Singleton.ActionManager.clear_history()
 		

--- a/scenes/actors/objects/area_transition/area_transition.gd
+++ b/scenes/actors/objects/area_transition/area_transition.gd
@@ -22,8 +22,8 @@ var entering := false
 var stored_characters : Array = [null, null]
 
 func _set_properties():
-	savable_properties = ["area_id", "destination_tag", "teleportation_mode", "vertical", "parts", "stops_camera"]
-	editable_properties = ["area_id", "destination_tag", "teleportation_mode", "vertical", "parts", "stops_camera"]
+	savable_properties = ["area_id", "destination_tag", "teleportation_mode", "vertical", "parts", "stops_camera", "force_fadeout"]
+	editable_properties = ["area_id", "destination_tag", "teleportation_mode", "vertical", "parts", "stops_camera", "force_fadeout"]
 	
 func _set_property_values():
 	set_property("area_id", area_id, true, "Area Destination")
@@ -33,6 +33,7 @@ func _set_property_values():
 	set_property("vertical", vertical)
 	set_property("parts", parts)
 	set_property("stops_camera", stops_camera)
+	set_property("force_fadeout", force_fadeout)
 #	set_property("instant", instant, true, "Instant (Local)")
 	
 func _init():
@@ -183,7 +184,7 @@ func start_pipe_enter_animation(character : Character) -> void:
 				Singleton.CurrentLevelData.level_data.vars.transition_character_data_2.append(AreaTransitionHelper.new(character.velocity, character.state, character.facing_direction, to_local(character.position), self.vertical))
 			character.camera.auto_move = false
 	
-	emit_signal("pipe_animation_finished", character, entering)
+	emit_signal("pipe_animation_finished", character, entering, force_fadeout)
 	
 	
 
@@ -195,7 +196,7 @@ func start_pipe_exit_animation(character : Character, tp_mode : bool) -> void:
 	
 
 	if !tp_mode:
-		emit_signal("exit", character, entering)
+		emit_signal("exit", character, entering, force_fadeout)
 		
 		# undo collision changes 
 		character.set_collision_layer_bit(1, true)

--- a/scenes/actors/objects/door/door.gd
+++ b/scenes/actors/objects/door/door.gd
@@ -11,8 +11,8 @@ var stored_character : Character
 const OPEN_DOOR_WAIT = 0.45
 
 func _set_properties() -> void:
-	savable_properties = ["area_id", "destination_tag", "teleportation_mode"]
-	editable_properties = ["area_id", "destination_tag", "teleportation_mode"]
+	savable_properties = ["area_id", "destination_tag", "teleportation_mode", "force_fadeout"]
+	editable_properties = ["area_id", "destination_tag", "teleportation_mode", "force_fadeout"]
 	
 func _set_property_values() -> void:
 
@@ -20,6 +20,7 @@ func _set_property_values() -> void:
 	set_property("destination_tag", destination_tag)
 	set_property("teleportation_mode", teleportation_mode, true, "Teleport Mode")
 	set_bool_alias("teleportation_mode", "Remote", "Local")
+	set_property("force_fadeout", force_fadeout)
 
 
 func _init():

--- a/scenes/actors/objects/door/door_enter_logic.gd
+++ b/scenes/actors/objects/door/door_enter_logic.gd
@@ -88,7 +88,7 @@ func start_door_enter_animation(character : Character) -> void:
 func character_animation_finished(_animation : String, character : Character) -> void:
 	# this is so the door closes after mario enters
 	animate_door("close")
-	emit_signal("start_door_logic", character, entering)
+	emit_signal("start_door_logic", character, entering, get_parent().force_fadeout)
 	
 func animate_door(animation : String = "close") -> void:
 	# this function just plays the door animation, so code doesn't have to repeat
@@ -108,7 +108,7 @@ func start_door_exit_animation(character : Character, tp_mode : bool) -> void:
 	character.toggle_movement(false)
 	
 	if !tp_mode:
-		emit_signal("exit", character, entering)
+		emit_signal("exit", character, entering, get_parent().force_fadeout)
 	
 	animate_door("open")
 	character.anim_player.play("exit_door")

--- a/scenes/actors/objects/pipe/pipe.gd
+++ b/scenes/actors/objects/pipe/pipe.gd
@@ -9,8 +9,8 @@ export var recolorable_texture : Texture
 var color := Color(0, 1, 0)
 
 func _set_properties():
-	savable_properties = ["area_id", "destination_tag", "color", "teleportation_mode"]
-	editable_properties = ["area_id", "destination_tag", "color", "teleportation_mode"]
+	savable_properties = ["area_id", "destination_tag", "color", "teleportation_mode", "force_fadeout"]
+	editable_properties = ["area_id", "destination_tag", "color", "teleportation_mode", "force_fadeout"]
 	
 func _set_property_values():
 	set_property("area_id", area_id, true, "Area Destination")
@@ -18,6 +18,7 @@ func _set_property_values():
 	set_property("color", color, true)
 	set_property("teleportation_mode", teleportation_mode, true, "Teleport Mode")
 	set_bool_alias("teleportation_mode", "Remote", "Local")
+	set_property("force_fadeout", force_fadeout)
 
 func _init():
 	teleportation_mode = true

--- a/scenes/actors/objects/pipe/pipe_enter_logic/pipe_enter_logic.gd
+++ b/scenes/actors/objects/pipe/pipe_enter_logic/pipe_enter_logic.gd
@@ -132,7 +132,7 @@ func start_pipe_exit_animation(character : Character, tp_mode : bool) -> void:
 	character.sprite.frame = 2
 	
 	if !tp_mode:
-		emit_signal("exit", character, entering)
+		emit_signal("exit", character, entering, get_parent().force_fadeout)
 	
 	# warning-ignore: return_value_discarded
 	tween.interpolate_property(character, "position:y", global_position.y + PIPE_BOTTOM_DISTANCE, \
@@ -172,7 +172,7 @@ func pipe_exit_anim_finished(character : Character):
 	
 func _tween_all_completed() -> void:
 	if entering: #TODO: Make this work w/o if statement
-		emit_signal("pipe_animation_finished", stored_character, entering)
+		emit_signal("pipe_animation_finished", stored_character, entering, get_parent().force_fadeout)
 		stored_character = null
 
 

--- a/scenes/actors/objects/star_door/star_door.gd
+++ b/scenes/actors/objects/star_door/star_door.gd
@@ -40,6 +40,7 @@ func _set_property_values() -> void:
 	set_bool_alias("teleportation_mode", "Remote", "Local")
 	set_property("collectible", collectible)
 	set_property("required_amount", required_amount)
+	set_property("force_fadeout", force_fadeout)
 
 
 func _init():

--- a/scenes/actors/objects/star_door/star_door_enter_logic.gd
+++ b/scenes/actors/objects/star_door/star_door_enter_logic.gd
@@ -115,7 +115,7 @@ func open_menu_ui(character):
 func character_animation_finished(_animation : String, character : Character) -> void:
 	# this is so the door closes after mario enters
 	animate_door("close")
-	emit_signal("start_door_logic", character, entering)
+	emit_signal("start_door_logic", character, entering, get_parent().force_fadeout)
 	
 func animate_door(animation : String = "close") -> void:
 	#print(get_parent().palette_dict[get_parent().palette] + "_" + get_parent().collectible + animation)
@@ -137,7 +137,7 @@ func start_door_exit_animation(character : Character, tp_mode : bool) -> void:
 	character.toggle_movement(false)
 	
 	if !tp_mode:
-		emit_signal("exit", character, entering)
+		emit_signal("exit", character, entering, get_parent().force_fadeout)
 	
 	animate_door("open")
 	character.anim_player.play("exit_door")

--- a/scenes/actors/scene_transitions/transition_script.gd
+++ b/scenes/actors/scene_transitions/transition_script.gd
@@ -25,7 +25,7 @@ func reload_scene(transition_in_tex = cutout_circle, transition_out_tex = cutout
 	if Singleton.ModeSwitcher.get_node("ModeSwitcherButton").invisible or !Singleton.ModeSwitcher.get_node("ModeSwitcherButton").switching_disabled:
 		var volume_multiplier = Singleton.Music.volume_multiplier
 
-		yield(do_transition_animation(transition_in_tex, transition_time, TRANSITION_SCALE_UNCOVER, TRANSITION_SCALE_COVERED, volume_multiplier, volume_multiplier / 4, false, true), "completed")
+		yield(do_transition_animation(transition_in_tex, transition_time, TRANSITION_SCALE_UNCOVER, TRANSITION_SCALE_COVERED, volume_multiplier, volume_multiplier / 4, false, false), "completed")
 		
 		Singleton.CurrentLevelData.stop_tracking_time_score()
 		if !r_press:
@@ -39,7 +39,7 @@ func reload_scene(transition_in_tex = cutout_circle, transition_out_tex = cutout
 		yield(get_tree().create_timer(0.1), "timeout")
 		get_tree().paused = false
 		
-		yield(do_transition_animation(transition_out_tex, transition_time, TRANSITION_SCALE_COVERED, TRANSITION_SCALE_UNCOVER, volume_multiplier / 4, volume_multiplier, false, true), "completed")
+		yield(do_transition_animation(transition_out_tex, transition_time, TRANSITION_SCALE_COVERED, TRANSITION_SCALE_UNCOVER, volume_multiplier / 4, volume_multiplier, false, false), "completed")
 
 func do_transition_fade(transition_time : float = DEFAULT_TRANSITION_TIME, start_alpha: float = 0, end_alpha: float = 1, reverse_after : bool = true):
 	var chosen_transition_color: Color = TRANSITION_COLOR

--- a/scenes/editor/placement/rectangle_fill.gd
+++ b/scenes/editor/placement/rectangle_fill.gd
@@ -119,9 +119,9 @@ func selected_update():
 
 
 func mouse_down() -> void:
-	fill_rect.position = Vector2(round(mouse_pos.x/TILE_SIZE), round(mouse_pos.y/TILE_SIZE))
+	fill_rect.position = Vector2(floor(mouse_pos.x/TILE_SIZE), floor(mouse_pos.y/TILE_SIZE))
 	
-	drag.rect_position = fill_rect.position*TILE_SIZE + Vector2(8, 8)
+	drag.rect_position = Vector2(floor(mouse_pos.x/TILE_SIZE), floor(mouse_pos.y/TILE_SIZE))
 	drag.rect_size = TILE
 	drag.visible = true
 	

--- a/scenes/editor/window/HelpWindow.tscn
+++ b/scenes/editor/window/HelpWindow.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource path="res://assets/fonts/delfino.ttf" type="DynamicFontData" id=1]
 [ext_resource path="res://assets/tiles/tiles.tres" type="TileSet" id=2]
-[ext_resource path="res://scenes/editor/window/tileset_scroll.gd" type="Script" id=3]
+[ext_resource path="res://scenes/editor/window/image_scroll.gd" type="Script" id=3]
 [ext_resource path="res://scenes/editor/window/HelpWindow.gd" type="Script" id=4]
 [ext_resource path="res://assets/styles/ButtonStyleNormal.tres" type="StyleBox" id=5]
 [ext_resource path="res://scenes/editor/window/HelpPage.gd" type="Script" id=6]
@@ -521,7 +521,7 @@ script = ExtResource( 4 )
 [node name="Title" type="RichTextLabel" parent="."]
 margin_left = 24.0
 margin_top = 24.0
-margin_right = 577.0
+margin_right = 837.0
 margin_bottom = 88.0
 mouse_filter = 2
 custom_fonts/normal_font = SubResource( 1 )
@@ -825,13 +825,16 @@ If you have further questions, ask in the discord server.
 fit_content_height = true
 scroll_active = false
 
-[node name="TileMap" type="TileMap" parent="Pages/Autotiling"]
+[node name="Images" type="Node2D" parent="Pages/Autotiling"]
+position = Vector2( 0, 126 )
+
+[node name="TileMap" type="TileMap" parent="Pages/Autotiling/Images"]
 tile_set = ExtResource( 2 )
 cell_size = Vector2( 32, 32 )
 format = 1
 tile_data = PoolIntArray( 65560, 8, 196621, 65561, 8, 131085, 65563, 5, 13, 65564, 4, 11, 131095, 8, 65549, 131096, 8, 65541, 131097, 8, 65542, 131098, 2, 13, 131099, 5, 65541, 131100, 2, 131083, 196631, 2, 65544, 196632, 2, 131081, 196633, 8, 131081, 196634, 2, 131081, 196635, 2, 131081, 196636, 2, 131083, 262167, 5, 196616, 262168, 8, 131077, 262169, 2, 131081, 262170, 2, 131081, 262171, 8, 131078, 262172, 8, 196619, 327704, 8, 196632, 327705, 8, 196617, 327706, 8, 196617, 327707, 8, 65560, 917527, 7, 7, 917528, 3, 1, 917529, 3, 1, 917530, 3, 1, 917531, 6, 6, 983063, 7, 9, 983064, 3, 1, 983065, 3, 1, 983066, 3, 1, 983067, 6, 8, 2031616, 2, 196608, 2031618, 5, 196608, 2031620, 4, 196608, 2031622, 8, 196608, 2228245, 2, 8, 2228246, 2, 11, 2293780, 2, 8, 2293781, 2, 65541, 2293782, 2, 131083, 2359315, 2, 196609, 2359316, 2, 196613, 2359317, 2, 196617, 2359318, 2, 196619, 2490391, 5, 13, 2490392, 4, 13, 2555926, 5, 13, 2555927, 5, 65541, 2555928, 4, 65542, 2555929, 4, 13, 2621461, 2, 196609, 2621462, 5, 196613, 2621463, 5, 196617, 2621464, 2, 196617, 2621465, 4, 196614, 2621466, 2, 196611, 2752534, 8, 196621, 2752535, 8, 10, 2752536, 8, 10, 2752537, 8, 131085, 2818064, 8, 196621, 2818065, 8, 131085, 2818068, 8, 196621, 2818069, 8, 65551, 2818070, 8, 65541, 2818071, 8, 131081, 2818072, 8, 65548, 2818073, 8, 65542, 2818074, 8, 16, 2883598, 8, 8, 2883599, 8, 65551, 2883600, 8, 65541, 2883601, 8, 65542, 2883602, 8, 15, 2883603, 8, 65551, 2883604, 8, 65541, 2883605, 2, 131081, 2883606, 2, 131081, 2883607, 2, 131081, 2883608, 2, 131081, 2883609, 2, 131081, 2883610, 4, 65542, 2883611, 8, 13, 2949134, 8, 196632, 2949135, 8, 196617, 2949136, 8, 196617, 2949137, 8, 196617, 2949138, 8, 196617, 2949139, 8, 196617, 2949140, 8, 196617, 2949141, 8, 196617, 2949142, 8, 196617, 2949143, 8, 196617, 2949144, 8, 196617, 2949145, 8, 196617, 2949146, 8, 196617, 2949147, 8, 65560, 3276817, 5, 15, 3342352, 5, 13, 3342353, 2, 65543, 3407887, 5, 196609, 3407888, 2, 196613, 3407889, 2, 196619, 3604483, 5, 15, 3604489, 5, 15, 3670018, 5, 13, 3670019, 2, 65543, 3670024, 5, 13, 3670025, 5, 65543, 3735553, 5, 196609, 3735554, 2, 196613, 3735555, 2, 196619, 3735559, 5, 196609, 3735560, 5, 196613, 3735561, 2, 196619, 4128788, 18, 8, 4128789, 18, 10, 4128790, 18, 10, 4128791, 18, 10, 4128792, 18, 10, 4128793, 18, 11, 4194324, 18, 65544, 4194325, 18, 131081, 4194326, 18, 131081, 4194327, 18, 131081, 4194328, 18, 131081, 4194329, 18, 131083, 4259860, 18, 196616, 4259861, 18, 196617, 4259862, 18, 196617, 4259863, 18, 196617, 4259864, 18, 196617, 4259865, 18, 196619, 4784148, 31, 0, 4784149, 33, 0, 4784150, 34, 0, 4784151, 32, 0, 4784153, 12, 0, 4784154, 9, 1, 4784155, 3, 1, 4784156, 15, 2 )
 
-[node name="TextureRect" type="TextureRect" parent="Pages/Autotiling/TileMap"]
+[node name="TextureRect" type="TextureRect" parent="Pages/Autotiling/Images/TileMap"]
 margin_left = 639.0
 margin_top = 2016.0
 margin_right = 832.0
@@ -839,9 +842,6 @@ margin_bottom = 2113.0
 size_flags_horizontal = 0
 texture = SubResource( 15 )
 stretch_mode = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Dialogue" type="ScrollContainer" parent="Pages"]
 visible = false
@@ -851,97 +851,27 @@ margin_right = 1426.5
 margin_bottom = 806.802
 theme = SubResource( 11 )
 scroll_horizontal_enabled = false
-script = ExtResource( 6 )
-page_name = "Dialogue & NPCs"
+script = ExtResource( 3 )
 
 [node name="RichTextLabel" type="RichTextLabel" parent="Pages/Dialogue"]
 margin_right = 978.0
-margin_bottom = 1443.0
+margin_bottom = 356.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_colors/default_color = Color( 1, 1, 1, 1 )
 custom_fonts/normal_font = SubResource( 13 )
 bbcode_enabled = true
-bbcode_text = "[center][color=yellow]--Hotkeys--[/color]
-[color=yellow]WASD Keys[/color] - Move Camera
-[color=yellow]Left Click[/color] - Place Tiles/Objects
-[color=yellow]Right Click[/color] - Delete Tiles/Objects
-
-[color=yellow]T[/color] - Toggle Play/Edit
-[color=yellow]L[/color] - Switch Layers
-[color=yellow]I[/color] - Focus on Current Layer
-[color=yellow]G[/color] - Toggle Grid
-
-[color=yellow]H[/color] - Switch Object Placement Mode
-[color=yellow]Hold CTRL[/color] - Precise Object Placement
-
-[color=yellow]Right Click Save Button[/color] - Open Autosave Menu
-
-[color=yellow]--While Hovering Over Object--[/color]
-[color=yellow]Left Click[/color] - Open Properties
-[color=yellow]R[/color] - Rotate Object
-[color=yellow]K[/color] - Toggle Enabled
-[color=yellow]F[/color] - Flip Object Horizontally
-[color=yellow]Y[/color] - Flip Object Vertically
-
-[color=yellow]Shift[/color] - Duplicate Object
-[color=yellow]Mouse Wheel[/color] - Change Platform Width
-
-[center][color=yellow]--Path Editor--[/color]
-[color=yellow]Left Click[/color] - Add Path Node
-[color=yellow]Right Click[/color] - Remove Path Node
-[color=yellow]CTRL + Left Click[/color] - Toggle Curve Handles on Selected Node
-[color=yellow]Hold Shift[/color] - Snap Nodes & Handles to 8x8 Grid
-
-[color=yellow]--Gameplay Hotkeys--[/color]
-[color=yellow]P[/color] - Open Pause Menu
-[color=yellow]R[/color] - Restart from Checkpoint
-[color=yellow]O[/color] - Restart from Beginning
-
-[color=yellow]--Other Hotkeys--[/color]
-[color=yellow]Tab[/color] - Toggle CRT Filter
-[/center]"
-text = "--Hotkeys--
-WASD Keys - Move Camera
-Left Click - Place Tiles/Objects
-Right Click - Delete Tiles/Objects
-
-T - Toggle Play/Edit
-L - Switch Layers
-I - Focus on Current Layer
-G - Toggle Grid
-
-H - Switch Object Placement Mode
-Hold CTRL - Precise Object Placement
-
-Right Click Save Button - Open Autosave Menu
-
---While Hovering Over Object--
-Left Click - Open Properties
-R - Rotate Object
-K - Toggle Enabled
-F - Flip Object Horizontally
-Y - Flip Object Vertically
-
-Shift - Duplicate Object
-Mouse Wheel - Change Platform Width
-
---Path Editor--
-Left Click - Add Path Node
-Right Click - Remove Path Node
-CTRL + Left Click - Toggle Curve Handles on Selected Node
-Hold Shift - Snap Nodes & Handles to 8x8 Grid
-
---Gameplay Hotkeys--
-P - Open Pause Menu
-R - Restart from Checkpoint
-O - Restart from Beginning
-
---Other Hotkeys--
-Tab - Toggle CRT Filter
+bbcode_text = "[center][color=yellow]--Dialogue--[/color][/center]
+Some helpful dialogue help amirite fellas?
+"
+text = "--Dialogue--
+Some helpful dialogue help amirite fellas?
 "
 fit_content_height = true
 scroll_active = false
+
+[node name="Images" type="Node2D" parent="Pages/Dialogue"]
+position = Vector2( -36, -126 )
 
 [node name="Tween" type="Tween" parent="."]
 

--- a/scenes/editor/window/LSSHelpWindow.tscn
+++ b/scenes/editor/window/LSSHelpWindow.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource path="res://assets/fonts/delfino.ttf" type="DynamicFontData" id=1]
 [ext_resource path="res://assets/tiles/tiles.tres" type="TileSet" id=2]
-[ext_resource path="res://scenes/editor/window/tileset_scroll.gd" type="Script" id=3]
+[ext_resource path="res://scenes/editor/window/image_scroll.gd" type="Script" id=3]
 [ext_resource path="res://scenes/editor/window.gd" type="Script" id=7]
 [ext_resource path="res://scenes/editor/sounds/click2.wav" type="AudioStream" id=13]
 [ext_resource path="res://scenes/editor/assets/window.png" type="Texture" id=14]

--- a/scenes/editor/window/SampleInfo.tscn
+++ b/scenes/editor/window/SampleInfo.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource path="res://assets/fonts/delfino.ttf" type="DynamicFontData" id=1]
 [ext_resource path="res://assets/tiles/tiles.tres" type="TileSet" id=2]
-[ext_resource path="res://scenes/editor/window/tileset_scroll.gd" type="Script" id=3]
+[ext_resource path="res://scenes/editor/window/image_scroll.gd" type="Script" id=3]
 [ext_resource path="res://scenes/editor/window.gd" type="Script" id=7]
 [ext_resource path="res://scenes/editor/sounds/click2.wav" type="AudioStream" id=13]
 [ext_resource path="res://scenes/editor/assets/window.png" type="Texture" id=14]

--- a/scenes/editor/window/image_scroll.gd
+++ b/scenes/editor/window/image_scroll.gd
@@ -1,0 +1,6 @@
+extends HelpPage
+
+onready var images = get_node("Images")
+
+func _process(delta):
+	images.position.y = -scroll_vertical

--- a/scenes/editor/window/tileset_scroll.gd
+++ b/scenes/editor/window/tileset_scroll.gd
@@ -1,6 +1,0 @@
-tool
-
-extends HelpPage
-
-func _process(delta):
-	$TileMap.position.y = -scroll_vertical


### PR DESCRIPTION
- power up music now carries over correctly from warping between areas
- above caused minor bug that causes power up music to play quietly for a slight bit when switching from playtesting to the editor
- fixed issue with rectangle fill visual not setting the proper position at the start of using it
- new property for warps that forces them to always use the circle fadeout no matter the distance