### PR TITLE
Checkpoint saves "Spawn Y Offset" property

### DIFF
--- a/scenes/actors/objects/checkpoint/checkpoint.gd
+++ b/scenes/actors/objects/checkpoint/checkpoint.gd
@@ -27,7 +27,7 @@ func _ready():
 	
 	var _connect = use_area.connect("body_entered", self, "set_checkpoint")
 	Singleton.CurrentLevelData.set_checkpoint_ids()
-	id = level_object.get_ref().properties[6]
+	id = level_object.get_ref().properties[7]
 	if Singleton.CheckpointSaved.current_checkpoint_id == id:
 		is_used = true
 	

--- a/scenes/shared/level_data.gd
+++ b/scenes/shared/level_data.gd
@@ -163,7 +163,7 @@ func set_checkpoint_ids():
 	for area in Singleton.CurrentLevelData.level_data.areas:
 		for object in area.objects:
 			if object.type_id == 82:
-				object.properties[6] = checkpoint_id
+				object.properties[7] = checkpoint_id
 				checkpoint_id += 1
 	return checkpoint_id
 

--- a/singletons/lss_ping.gd
+++ b/singletons/lss_ping.gd
@@ -20,7 +20,7 @@ func update_status():
 			"Authorization: Bearer " + token
 		]
 		var error: int = request(
-			"https://levelsharesquare.com/api/app/intervals/SM127", 
+			"https://levelsharesquare.com/api/app/intervals/SM127?hidden=true", 
 			header, 
 			true, 
 			HTTPClient.METHOD_POST


### PR DESCRIPTION
Turns out this property was being overwritten by the checkpoint's ID.
Changing which index the ID references fixes this bug.