### PR TITLE
Text inputs can be re-opened when closed by any button

### DIFF
--- a/scenes/editor/property_type_scenes/PoolStringArray/base/CancelButton.gd
+++ b/scenes/editor/property_type_scenes/PoolStringArray/base/CancelButton.gd
@@ -9,7 +9,7 @@ var string: Control
 
 func _pressed():
 	string.toggle_pressed()
-	get_parent().get_parent().close()
+	get_owner().close()
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 #func _process(delta):
 #	pass

--- a/scenes/editor/property_type_scenes/PoolStringArray/base/CloseButton.gd
+++ b/scenes/editor/property_type_scenes/PoolStringArray/base/CloseButton.gd
@@ -1,4 +1,5 @@
-extends Button
+extends TextureButton
+
 
 var string: Control
 
@@ -9,7 +10,7 @@ var string: Control
 
 func _pressed():
 	string.toggle_pressed()
-	get_parent().get_parent().close()
+	get_parent().close()
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 #func _process(delta):
 #	pass

--- a/scenes/editor/property_type_scenes/PoolStringArray/base/DialogueInput.tscn
+++ b/scenes/editor/property_type_scenes/PoolStringArray/base/DialogueInput.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=27 format=2]
+[gd_scene load_steps=29 format=2]
 
 [ext_resource path="res://scenes/editor/sounds/click2.wav" type="AudioStream" id=1]
 [ext_resource path="res://scenes/editor/sounds/hover.wav" type="AudioStream" id=2]
@@ -8,12 +8,14 @@
 [ext_resource path="res://scenes/editor/assets/window.png" type="Texture" id=6]
 [ext_resource path="res://assets/fonts/delfino.ttf" type="DynamicFontData" id=7]
 [ext_resource path="res://scenes/editor/property_type_scenes/PoolStringArray/base/DialogueSaveButton.gd" type="Script" id=8]
+[ext_resource path="res://scenes/editor/property_type_scenes/PoolStringArray/base/CancelButton.gd" type="Script" id=9]
 [ext_resource path="res://assets/styles/ButtonStyleDisabled.tres" type="StyleBox" id=10]
 [ext_resource path="res://scenes/editor/property_type_scenes/PoolStringArray/base/body_preview.png" type="Texture" id=11]
 [ext_resource path="res://scenes/editor/property_type_scenes/PoolStringArray/base/head_preview.png" type="Texture" id=12]
 [ext_resource path="res://scenes/editor/property_type_scenes/PoolStringArray/base/facing_dir.gd" type="Script" id=13]
 [ext_resource path="res://scenes/shared/ui/selector.tres" type="Theme" id=14]
 [ext_resource path="res://scenes/editor/property_type_scenes/PoolStringArray/base/player_preview.png" type="Texture" id=15]
+[ext_resource path="res://scenes/editor/property_type_scenes/PoolStringArray/base/CloseButton.gd" type="Script" id=16]
 
 [sub_resource type="DynamicFont" id=1]
 size = 56
@@ -121,6 +123,7 @@ bbcode_text = "Text"
 text = "Text"
 
 [node name="CloseButton" type="TextureButton" parent="."]
+unique_name_in_owner = true
 anchor_left = 1.0
 anchor_right = 1.0
 margin_left = -170.0
@@ -130,6 +133,7 @@ rect_scale = Vector2( 0.95, 0.95 )
 texture_normal = ExtResource( 5 )
 texture_pressed = ExtResource( 5 )
 texture_hover = ExtResource( 4 )
+script = ExtResource( 16 )
 
 [node name="HoverSound" type="AudioStreamPlayer" parent="CloseButton"]
 stream = ExtResource( 2 )
@@ -432,6 +436,7 @@ custom_styles/normal = SubResource( 15 )
 shortcut_in_tooltip = false
 action_mode = 0
 text = "Cancel"
+script = ExtResource( 9 )
 
 [node name="HoverSound" type="AudioStreamPlayer" parent="Contents/VBoxContainer/Buttons/CancelButton"]
 stream = ExtResource( 2 )

--- a/scenes/editor/property_type_scenes/PoolStringArray/base/base.gd
+++ b/scenes/editor/property_type_scenes/PoolStringArray/base/base.gd
@@ -2,7 +2,7 @@ extends Control
 
 export var line_edit : NodePath
 
-var pressed = false
+var is_pressed = false
 var last_hovered = false
 
 onready var hover_sound = $HoverSound
@@ -20,7 +20,7 @@ func _process(_delta):
 	last_hovered = text.is_hovered()
 
 func pressed():
-	if pressed == false:
+	if is_pressed == false:
 		click_sound.play()
 		var window = preload("res://scenes/editor/property_type_scenes/PoolStringArray/base/DialogueInput.tscn")
 		var window_child = window.instance()
@@ -28,8 +28,10 @@ func pressed():
 		get_parent().get_parent().get_parent().get_parent().add_child(window_child)
 		window_child.set_as_toplevel(true)
 		window_child.get_node("%TextEdit").text = dialogue[0]
+		window_child.get_node("%CancelButton").string = self
+		window_child.get_node("%CloseButton").string = self
 		window_child.get_node("%SaveButton").string = self
-		pressed = true
+		toggle_pressed()
 
 
 func set_value(value: PoolStringArray):
@@ -39,5 +41,9 @@ func get_value() -> PoolStringArray:
 	return dialogue
 
 func update_value():
-	pressed = false
+	toggle_pressed()
 	get_node("../").update_value(get_value())
+
+func toggle_pressed() -> void:
+	
+	is_pressed = !is_pressed

--- a/scenes/editor/property_type_scenes/string/base/base.gd
+++ b/scenes/editor/property_type_scenes/string/base/base.gd
@@ -2,7 +2,7 @@ extends Control
 
 export var line_edit : NodePath
 
-var pressed = false
+var is_pressed = false
 var last_hovered = false
 
 onready var hover_sound = $HoverSound
@@ -18,7 +18,7 @@ func _process(_delta):
 	last_hovered = text.is_hovered()
 
 func pressed():
-	if pressed == false:
+	if is_pressed == false:
 		click_sound.play()
 		var window = preload("res://scenes/editor/window/TextInput.tscn")
 		var window_child = window.instance()
@@ -27,8 +27,9 @@ func pressed():
 		window_child.set_as_toplevel(true)
 		window_child.get_node("Contents/TextEdit").text = text.text
 		window_child.get_node("Contents/CancelButton").string = self
+		window_child.get_node("CloseButton").string = self
 		window_child.get_node("Contents/SaveButton").string = self
-		pressed = true
+		toggle_pressed()
 
 
 func set_value(value: String):
@@ -38,5 +39,9 @@ func get_value() -> String:
 	return text.text
 
 func update_value():
-	pressed = false
+	toggle_pressed()
 	get_node("../").update_value(get_value())
+
+func toggle_pressed() -> void:
+	
+	is_pressed = !is_pressed

--- a/scenes/editor/window/CloseButton.gd
+++ b/scenes/editor/window/CloseButton.gd
@@ -1,4 +1,5 @@
-extends Button
+extends TextureButton
+
 
 var string: Control
 
@@ -9,7 +10,7 @@ var string: Control
 
 func _pressed():
 	string.toggle_pressed()
-	get_parent().get_parent().close()
+	get_parent().close()
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 #func _process(delta):
 #	pass

--- a/scenes/editor/window/TextInput.tscn
+++ b/scenes/editor/window/TextInput.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=17 format=2]
 
 [ext_resource path="res://scenes/editor/sounds/click2.wav" type="AudioStream" id=1]
 [ext_resource path="res://scenes/editor/sounds/hover.wav" type="AudioStream" id=2]
@@ -9,6 +9,7 @@
 [ext_resource path="res://assets/fonts/delfino.ttf" type="DynamicFontData" id=7]
 [ext_resource path="res://scenes/editor/window/SaveButton.gd" type="Script" id=8]
 [ext_resource path="res://scenes/editor/window/CancelButton.gd" type="Script" id=9]
+[ext_resource path="res://scenes/editor/window/CloseButton.gd" type="Script" id=10]
 
 [sub_resource type="DynamicFont" id=1]
 size = 56
@@ -84,9 +85,7 @@ rect_scale = Vector2( 0.95, 0.95 )
 texture_normal = ExtResource( 5 )
 texture_pressed = ExtResource( 5 )
 texture_hover = ExtResource( 4 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource( 10 )
 
 [node name="HoverSound" type="AudioStreamPlayer" parent="CloseButton"]
 stream = ExtResource( 2 )

--- a/scenes/editor/window/TextInput2.tscn
+++ b/scenes/editor/window/TextInput2.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=17 format=2]
 
 [ext_resource path="res://scenes/editor/sounds/click2.wav" type="AudioStream" id=1]
 [ext_resource path="res://scenes/editor/sounds/hover.wav" type="AudioStream" id=2]
@@ -9,6 +9,7 @@
 [ext_resource path="res://assets/fonts/delfino.ttf" type="DynamicFontData" id=7]
 [ext_resource path="res://scenes/editor/window/SaveButton2.gd" type="Script" id=8]
 [ext_resource path="res://scenes/editor/window/CancelButton.gd" type="Script" id=9]
+[ext_resource path="res://scenes/editor/window/CloseButton.gd" type="Script" id=10]
 
 [sub_resource type="DynamicFont" id=1]
 size = 56
@@ -84,9 +85,7 @@ rect_scale = Vector2( 0.95, 0.95 )
 texture_normal = ExtResource( 5 )
 texture_pressed = ExtResource( 5 )
 texture_hover = ExtResource( 4 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource( 10 )
 
 [node name="HoverSound" type="AudioStreamPlayer" parent="CloseButton"]
 stream = ExtResource( 2 )


### PR DESCRIPTION
Text input windows that allow users to input string values now toggle a value whenever their window is closed, instead of just when saving a value to the field.
This prevents input windows from getting stuck in a state where they can't be opened again until the entire object properties window is re-loaded.