### PR TITLE
Rexes that are disabled and squished use the squished sprite

### DIFF
--- a/scenes/actors/objects/rex/rex.gd
+++ b/scenes/actors/objects/rex/rex.gd
@@ -232,6 +232,11 @@ func _physics_process(delta:float)->void :
 	if mode != 1 and enabled:
 		sprite.animation = "walking" if not squish else "walking_squished"
 		update_eyes()
+	
+	elif squish:
+		
+		sprite.animation = "squished"
+		
 	else:
 		sprite.animation = "default"
 	

--- a/scenes/actors/objects/rex/rex.tres
+++ b/scenes/actors/objects/rex/rex.tres
@@ -7,6 +7,10 @@
 atlas = ExtResource( 1 )
 region = Rect2( 125, 0, 25, 32 )
 
+[sub_resource type="AtlasTexture" id=5]
+atlas = ExtResource( 2 )
+region = Rect2( 2, 0, 25, 32 )
+
 [sub_resource type="AtlasTexture" id=1]
 atlas = ExtResource( 1 )
 region = Rect2( 0, 0, 25, 32 )
@@ -22,10 +26,6 @@ region = Rect2( 50, 0, 25, 32 )
 [sub_resource type="AtlasTexture" id=4]
 atlas = ExtResource( 1 )
 region = Rect2( 75, 0, 25, 32 )
-
-[sub_resource type="AtlasTexture" id=5]
-atlas = ExtResource( 2 )
-region = Rect2( 2, 0, 25, 32 )
 
 [sub_resource type="AtlasTexture" id=6]
 atlas = ExtResource( 2 )
@@ -48,6 +48,11 @@ animations = [ {
 "frames": [ SubResource( 10 ) ],
 "loop": true,
 "name": "default",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 5 ) ],
+"loop": true,
+"name": "squished",
 "speed": 5.0
 }, {
 "frames": [ SubResource( 1 ), SubResource( 2 ), SubResource( 3 ), SubResource( 4 ) ],


### PR DESCRIPTION
Rexes now use their squished sprite whenever their squish property is set to true, even when disabled.