### PR TITLE
Disabled sawblades no longer interact with the player

### DIFF
--- a/scenes/actors/objects/sawblade/Saw.gd
+++ b/scenes/actors/objects/sawblade/Saw.gd
@@ -14,6 +14,9 @@ func is_metal_or_rainbow(body):
 	return body.powerup != null and (body.powerup.id == "Metal" or body.powerup.id == "Rainbow")
 
 func kill(body):
+	
+	enabled = get_parent().get_parent().get_parent().enabled
+	
 	if !(enabled and body.name.begins_with("Character") and !body.dead and body.controllable):
 		return
 	


### PR DESCRIPTION
When a player enters the hitbox of a disabled sawblade it will no longer have any sort of effect on the player.