### PR TITLE
Quit without saving window fix

### DIFF
--- a/scenes/editor/quit_wo_saving_window.gd
+++ b/scenes/editor/quit_wo_saving_window.gd
@@ -3,7 +3,13 @@ extends Popup
 onready var ok_button = $HBoxContainer/OkButton
 onready var cancel_button = $HBoxContainer/CancelButton
 
+var open_window: EditorWindow setget set_open_window
+
 signal confirmed
+
+func set_open_window(window: EditorWindow)-> void:
+	
+	open_window = window
 
 func _ready():
 	var _connect
@@ -15,3 +21,6 @@ func on_ok_pressed():
 
 func on_cancel_pressed():
 	visible = false
+	
+	if (open_window != null):
+		open_window.open()

--- a/scenes/editor/window.gd
+++ b/scenes/editor/window.gd
@@ -46,7 +46,13 @@ func open():
 		yield(tween, "tween_completed")
 		Singleton2.disable_hotkeys = true
 	
-func close():
+	var back_button = get_parent().get_node("BackButton")
+	back_button.connect("open_quit_wo_saving_popup",self,"temporary_close")
+	
+	var quit_wo_saving_window = back_button.get_node("QuitWOSavingWindow")
+	quit_wo_saving_window.set_open_window(self)
+
+func temporary_close()-> void:
 	if visible:
 		rect_scale = Vector2(0.4, 0.4)
 		tween.interpolate_property(self, "rect_scale",
@@ -56,6 +62,13 @@ func close():
 		yield(tween, "tween_completed")
 		visible = false
 		Singleton2.disable_hotkeys = false
+
+func close():
+	
+	var quit_wo_saving_window = get_parent().get_node("BackButton").get_node("QuitWOSavingWindow")
+	quit_wo_saving_window.set_open_window(null)
+	
+	temporary_close()
 
 func _ready():
 	close_button.texture_normal = load(close_button.texture_normal.load_path)


### PR DESCRIPTION
Opening the quit without saving window now closes the active window (if there is one), and re-opens that window if cancel is pressed.