### PR TITLE
Object parts scroll check

### DIFF
--- a/classes/GameObject.gd
+++ b/classes/GameObject.gd
@@ -263,3 +263,85 @@ func update_layer():
 
 func get_shared():
 	return get_parent().get_parent()
+
+func is_window_open()-> bool:
+	
+	if (get_parent().name != "Objects"):
+		
+		return true
+	
+	# Get the Editor UI Node
+	var UI: CanvasLayer = get_parent().get_parent().get_parent().get_node("UI")
+	
+	if (UI == null):
+		
+		return true
+	
+	# Get all the potentially open windows
+	var quit_wo_saving_window: Popup = UI.get_node("BackButton").get_node("QuitWOSavingWindow")
+	var level_settings_window: NinePatchRect = UI.get_node("LevelSettingsWindow")
+	var object_settings_window: NinePatchRect = UI.get_node("ObjectSettingsWindow")
+	var level_code_window: NinePatchRect = UI.get_node("LevelCodeWindow") # Not currently used
+	var areas_window: NinePatchRect = UI.get_node("AreasWindow")
+	var colour_picker_window: NinePatchRect = UI.get_node("ColorPickerWindow") # Shouldn't need to check this window
+	var help_window: NinePatchRect = UI.get_node("HelpWindow")
+	var auto_save_window: NinePatchRect = UI.get_node("AutosaveWINDOW")
+	
+	var windows: Array = [quit_wo_saving_window,level_settings_window,object_settings_window,
+		areas_window,help_window,auto_save_window]
+	
+	for window in windows:
+		
+		if (window.visible): # if a window is visible, it's open
+			return true
+	
+	return false
+
+func is_mouse_over_area()-> bool:
+	
+	var mouse_pos: Vector2
+	
+	# Get the Editor UI Node
+	var UI: CanvasLayer = get_parent().get_parent().get_parent().get_node("UI")
+	
+	if (UI == null):
+		return true
+	
+	# Get all the potential overlapping areas
+	var placeable_items_container: TextureRect = UI.get_node("PlaceableItemsContainer")
+	var item_picker: TextureRect = UI.get_node("ItemPicker")
+	var item_picker_bottom: TextureRect
+	var item_picker_close_button: Button
+	if (item_picker.visible):
+		
+		item_picker_bottom = item_picker.get_node("Bottom")
+		item_picker_close_button = item_picker.get_node("CloseButton")
+	
+	var areas: Array = [placeable_items_container,item_picker,item_picker_bottom,item_picker_close_button]
+	
+	for area in areas:
+		
+		if (area == null || !area.visible): # Don't check for areas that aren't visible
+			continue
+		
+		if (area.hovered):
+			
+			return true
+	
+	# none of the areas are currently hovered over
+	return false
+
+func parts_input_handler(event,object):
+	if (is_window_open() || is_mouse_over_area()):
+		return
+	if event is InputEventMouseButton and event.is_pressed() and hovered:
+		if event.button_index == 5: # Mouse wheel down
+			object.parts -= 1
+			if object.parts < 1:
+				object.parts = 1
+			object.set_property("parts", object.parts, true)
+			object.update_parts()
+		elif event.button_index == 4: # Mouse wheel up
+			object.parts += 1
+			object.set_property("parts", object.parts, true)
+			object.update_parts()

--- a/classes/GameObject.gd
+++ b/classes/GameObject.gd
@@ -264,7 +264,7 @@ func update_layer():
 func get_shared():
 	return get_parent().get_parent()
 
-func is_window_open()-> bool:
+func is_mouse_over_window()-> bool:
 	
 	var UI: CanvasLayer
 	
@@ -295,7 +295,7 @@ func is_window_open()-> bool:
 	
 	for window in windows:
 		
-		if (window.visible):
+		if (window.hovered):
 			return true
 	
 	return false
@@ -338,7 +338,7 @@ func is_mouse_over_area()-> bool:
 	return false
 
 func parts_input_handler(event,object):
-	if (is_window_open() || is_mouse_over_area()):
+	if (is_mouse_over_window() || is_mouse_over_area()):
 		return
 	if event is InputEventMouseButton and event.is_pressed() and hovered:
 		if event.button_index == 5: # Mouse wheel down

--- a/classes/GameObject.gd
+++ b/classes/GameObject.gd
@@ -266,15 +266,18 @@ func get_shared():
 
 func is_window_open()-> bool:
 	
-	if (get_parent().name != "Objects"):
-		
-		return true
+	var UI: CanvasLayer
 	
 	# Get the Editor UI Node
-	var UI: CanvasLayer = get_parent().get_parent().get_parent().get_node("UI")
+	if (get_parent().name != "Objects"):
+		
+		UI = get_tree().root.get_node_or_null("Editor/UI")
+	
+	else:
+		
+		UI = get_parent().get_parent().get_parent().get_node_or_null("UI")
 	
 	if (UI == null):
-		
 		return true
 	
 	# Get all the potentially open windows
@@ -283,16 +286,16 @@ func is_window_open()-> bool:
 	var object_settings_window: NinePatchRect = UI.get_node("ObjectSettingsWindow")
 	var level_code_window: NinePatchRect = UI.get_node("LevelCodeWindow") # Not currently used
 	var areas_window: NinePatchRect = UI.get_node("AreasWindow")
-	var colour_picker_window: NinePatchRect = UI.get_node("ColorPickerWindow") # Shouldn't need to check this window
+	var colour_picker_window: NinePatchRect = UI.get_node("ColorPickerWindow")
 	var help_window: NinePatchRect = UI.get_node("HelpWindow")
 	var auto_save_window: NinePatchRect = UI.get_node("AutosaveWINDOW")
 	
 	var windows: Array = [quit_wo_saving_window,level_settings_window,object_settings_window,
-		areas_window,help_window,auto_save_window]
+		areas_window,colour_picker_window,help_window,auto_save_window]
 	
 	for window in windows:
 		
-		if (window.visible): # if a window is visible, it's open
+		if (window.visible):
 			return true
 	
 	return false
@@ -302,10 +305,13 @@ func is_mouse_over_area()-> bool:
 	var mouse_pos: Vector2
 	
 	# Get the Editor UI Node
-	var UI: CanvasLayer = get_parent().get_parent().get_parent().get_node("UI")
+	var UI: CanvasLayer = get_parent().get_parent().get_parent().get_node_or_null("UI")
 	
 	if (UI == null):
-		return true
+		
+		UI = get_parent().get_parent().get_parent().get_parent()
+		if (UI == null):
+			return true
 	
 	# Get all the potential overlapping areas
 	var placeable_items_container: TextureRect = UI.get_node("PlaceableItemsContainer")

--- a/scenes/actors/objects/area_transition/area_transition.gd
+++ b/scenes/actors/objects/area_transition/area_transition.gd
@@ -62,15 +62,7 @@ func _ready():
 	$Area2D.connect("body_entered", self, "_on_body_entered")
 
 func _input(event):
-	if event is InputEventMouseButton and event.is_pressed() and hovered:
-		if event.button_index == 5: # Mouse wheel down
-			parts -= 1
-			if parts < 1:
-				parts = 1
-			set_property("parts", parts, true)
-		elif event.button_index == 4: # Mouse wheel up
-			parts += 1
-			set_property("parts", parts, true)
+	parts_input_handler(event,self)
 			
 func update_property(key, value):
 	match(key):

--- a/scenes/actors/objects/buoyant_platform/buoyant_platform.gd
+++ b/scenes/actors/objects/buoyant_platform/buoyant_platform.gd
@@ -21,15 +21,7 @@ func _set_property_values():
 	set_property("physics_enabled", physics_enabled)
 
 func _input(event):
-	if event is InputEventMouseButton and event.is_pressed() and hovered:
-		if event.button_index == 5: # Mouse wheel down
-			parts -= 1
-			if parts < 1:
-				parts = 1
-			set_property("parts", parts, true)
-		elif event.button_index == 4: # Mouse wheel up
-			parts += 1
-			set_property("parts", parts, true)
+	parts_input_handler(event,self)
 
 func _process(_delta):
 	if parts != last_parts:

--- a/scenes/actors/objects/death_plane/death_plane.gd
+++ b/scenes/actors/objects/death_plane/death_plane.gd
@@ -23,15 +23,7 @@ func _set_property_values():
 	set_property("vertical", vertical)
 	
 func _input(event):
-	if event is InputEventMouseButton and event.is_pressed() and hovered:
-		if event.button_index == 5: # Mouse wheel down
-			parts -= 1
-			if parts < 1:
-				parts = 1
-			set_property("parts", parts, true)
-		elif event.button_index == 4: # Mouse wheel up
-			parts += 1
-			set_property("parts", parts, true)
+	parts_input_handler(event,self)
 
 	
 func _ready():

--- a/scenes/actors/objects/death_plane/death_plane.tscn
+++ b/scenes/actors/objects/death_plane/death_plane.tscn
@@ -29,15 +29,7 @@ func _set_property_values():
 	set_property(\"vertical\", vertical)
 	
 func _input(event):
-	if event is InputEventMouseButton and event.is_pressed() and hovered:
-		if event.button_index == 5: # Mouse wheel down
-			parts -= 1
-			if parts < 1:
-				parts = 1
-			set_property(\"parts\", parts, true)
-		elif event.button_index == 4: # Mouse wheel up
-			parts += 1
-			set_property(\"parts\", parts, true)
+	parts_input_handler(event,self)
 
 	
 func _ready():

--- a/scenes/actors/objects/metal_platform/metal_platform.gd
+++ b/scenes/actors/objects/metal_platform/metal_platform.gd
@@ -21,15 +21,7 @@ func _set_property_values():
 	set_property("color", color, 1)
 
 func _input(event):
-	if event is InputEventMouseButton and event.is_pressed() and hovered:
-		if event.button_index == 5: # Mouse wheel down
-			parts -= 1
-			if parts < 1:
-				parts = 1
-			set_property("parts", parts, true)
-		elif event.button_index == 4: # Mouse wheel up
-			parts += 1
-			set_property("parts", parts, true)
+	parts_input_handler(event,self)
 
 func _process(_delta):
 	if mode == 1:

--- a/scenes/actors/objects/metal_platform/resizable_semisolid.gd
+++ b/scenes/actors/objects/metal_platform/resizable_semisolid.gd
@@ -17,15 +17,7 @@ func _set_property_values():
 	set_property("parts", parts, 1)
 
 func _input(event):
-	if event is InputEventMouseButton and event.is_pressed() and hovered:
-		if event.button_index == 5: # Mouse wheel down
-			parts -= 1
-			if parts < 1:
-				parts = 1
-			set_property("parts", parts, true)
-		elif event.button_index == 4: # Mouse wheel up
-			parts += 1
-			set_property("parts", parts, true)
+	parts_input_handler(event,self)
 
 func _process(_delta):
 	if palette != 0:

--- a/scenes/actors/objects/mushroom_body/mushroom_stem.gd
+++ b/scenes/actors/objects/mushroom_body/mushroom_stem.gd
@@ -17,15 +17,7 @@ func _set_property_values():
 	set_property("parts", parts, true)
 
 func _input(event):
-	if event is InputEventMouseButton and event.is_pressed() and hovered:
-		if event.button_index == 5: # Mouse wheel down
-			parts -= 1
-			if parts < 1:
-				parts = 1
-			set_property("parts", parts)
-		elif event.button_index == 4: # Mouse wheel up
-			parts += 1
-			set_property("parts", parts)
+	parts_input_handler(event,self)
 
 func update_property(key, value):
 	update_parts()

--- a/scenes/actors/objects/note_block/note_block.gd
+++ b/scenes/actors/objects/note_block/note_block.gd
@@ -52,15 +52,7 @@ func _ready():
 	update_parts()
 
 func _input(event):
-	if event is InputEventMouseButton and event.is_pressed() and hovered:
-		if event.button_index == 5: # Mouse wheel down
-			parts -= 1
-			if parts < 1:
-				parts = 1
-			set_property("parts", parts, true)
-		elif event.button_index == 4: # Mouse wheel up
-			parts += 1
-			set_property("parts", parts, true)
+	parts_input_handler(event,self)
 
 func _physics_process(delta):
 	for object in blacklisted_bodies.keys():

--- a/scenes/actors/objects/on_off_platform_wheel/on_off_platform_wheel.gd
+++ b/scenes/actors/objects/on_off_platform_wheel/on_off_platform_wheel.gd
@@ -40,6 +40,8 @@ func _set_property_values():
 	set_property("inverted", inverted)
 
 func _input(event):
+	if (.is_window_open() || .is_mouse_over_area()):
+		return
 	if event is InputEventMouseButton and event.is_pressed() and hovered:
 		if event.button_index == 5: # Mouse wheel down
 			parts -= 1

--- a/scenes/actors/objects/on_off_platform_wheel/on_off_platform_wheel.gd
+++ b/scenes/actors/objects/on_off_platform_wheel/on_off_platform_wheel.gd
@@ -40,7 +40,7 @@ func _set_property_values():
 	set_property("inverted", inverted)
 
 func _input(event):
-	if (.is_window_open() || .is_mouse_over_area()):
+	if (.is_mouse_over_window() || .is_mouse_over_area()):
 		return
 	if event is InputEventMouseButton and event.is_pressed() and hovered:
 		if event.button_index == 5: # Mouse wheel down

--- a/scenes/actors/objects/on_off_touch_lift/on_off_touch_lift.gd
+++ b/scenes/actors/objects/on_off_touch_lift/on_off_touch_lift.gd
@@ -52,7 +52,7 @@ func _set_property_values():
 	set_property_menu("path_length", ["viewer"])
 
 func _input(event):
-	if (.is_window_open() || .is_mouse_over_area()):
+	if (.is_mouse_over_window() || .is_mouse_over_area()):
 		return
 	if event is InputEventMouseButton and event.is_pressed() and hovered:
 		if event.button_index == 5: # Mouse wheel down

--- a/scenes/actors/objects/on_off_touch_lift/on_off_touch_lift.gd
+++ b/scenes/actors/objects/on_off_touch_lift/on_off_touch_lift.gd
@@ -52,6 +52,8 @@ func _set_property_values():
 	set_property_menu("path_length", ["viewer"])
 
 func _input(event):
+	if (.is_window_open() || .is_mouse_over_area()):
+		return
 	if event is InputEventMouseButton and event.is_pressed() and hovered:
 		if event.button_index == 5: # Mouse wheel down
 			parts -= 1

--- a/scenes/actors/objects/pipe_body/pipe_body.gd
+++ b/scenes/actors/objects/pipe_body/pipe_body.gd
@@ -53,12 +53,4 @@ func _process(_delta):
 	last_parts = parts
 
 func _input(event):
-	if event is InputEventMouseButton and event.is_pressed() and hovered:
-		if event.button_index == 5: # Mouse wheel down
-			parts -= 1
-			if parts < 1:
-				parts = 1
-			set_property("parts", parts, true)
-		elif event.button_index == 4: # Mouse wheel up
-			parts += 1
-			set_property("parts", parts, true)
+	parts_input_handler(event,self)

--- a/scenes/actors/objects/platform_wheel/platform_wheel.gd
+++ b/scenes/actors/objects/platform_wheel/platform_wheel.gd
@@ -37,6 +37,8 @@ func _set_property_values():
 	set_property("start_angle", start_angle)
 
 func _input(event):
+	if (.is_window_open() || .is_mouse_over_area()):
+		return
 	if event is InputEventMouseButton and event.is_pressed() and hovered:
 		if event.button_index == 5: # Mouse wheel down
 			parts -= 1

--- a/scenes/actors/objects/platform_wheel/platform_wheel.gd
+++ b/scenes/actors/objects/platform_wheel/platform_wheel.gd
@@ -37,7 +37,7 @@ func _set_property_values():
 	set_property("start_angle", start_angle)
 
 func _input(event):
-	if (.is_window_open() || .is_mouse_over_area()):
+	if (.is_mouse_over_window() || .is_mouse_over_area()):
 		return
 	if event is InputEventMouseButton and event.is_pressed() and hovered:
 		if event.button_index == 5: # Mouse wheel down

--- a/scenes/actors/objects/seesaw/seesaw.gd
+++ b/scenes/actors/objects/seesaw/seesaw.gd
@@ -17,15 +17,7 @@ func _set_property_values():
 	set_property("can_rotate", can_rotate, 1)
 
 func _input(event):
-	if event is InputEventMouseButton and event.is_pressed() and hovered:
-		if event.button_index == 5: # Mouse wheel down
-			parts -= 1
-			if parts < 1:
-				parts = 1
-			set_property("parts", parts, true)
-		elif event.button_index == 4: # Mouse wheel up
-			parts += 1
-			set_property("parts", parts, true)
+	parts_input_handler(event,self)
 
 
 func update_property(key, value):

--- a/scenes/actors/objects/touch_lift/touch_lift.gd
+++ b/scenes/actors/objects/touch_lift/touch_lift.gd
@@ -53,7 +53,7 @@ func _set_property_values():
 	set_property_menu("path_length", ["viewer"])
 	
 func _input(event):
-	if (.is_window_open() || .is_mouse_over_area()):
+	if (.is_mouse_over_window() || .is_mouse_over_area()):
 		return
 	if event is InputEventMouseButton and event.is_pressed() and hovered:
 		if event.button_index == 5: # Mouse wheel down

--- a/scenes/actors/objects/touch_lift/touch_lift.gd
+++ b/scenes/actors/objects/touch_lift/touch_lift.gd
@@ -53,6 +53,8 @@ func _set_property_values():
 	set_property_menu("path_length", ["viewer"])
 	
 func _input(event):
+	if (.is_window_open() || .is_mouse_over_area()):
+		return
 	if event is InputEventMouseButton and event.is_pressed() and hovered:
 		if event.button_index == 5: # Mouse wheel down
 			parts -= 1

--- a/scenes/actors/objects/vine_stem/vine_stem.gd
+++ b/scenes/actors/objects/vine_stem/vine_stem.gd
@@ -34,15 +34,7 @@ func _ready():
 		sprite.texture = palette_textures[palette - 1]
 		
 func _input(event):
-	if event is InputEventMouseButton and event.is_pressed() and hovered:
-		if event.button_index == 5: # Mouse wheel down
-			parts -= 1
-			if parts < 1:
-				parts = 1
-			set_property("parts", parts, true)
-		elif event.button_index == 4: # Mouse wheel up
-			parts += 1
-			set_property("parts", parts, true)
+	parts_input_handler(event,self)
 
 func _process(_delta):
 	if parts != last_parts:

--- a/scenes/actors/objects/vine_thorns/vine_thorns.gd
+++ b/scenes/actors/objects/vine_thorns/vine_thorns.gd
@@ -36,15 +36,7 @@ func _ready():
 		$Sprite.texture = palette_textures[palette - 1]
 		
 func _input(event):
-	if event is InputEventMouseButton and event.is_pressed() and hovered:
-		if event.button_index == 5: # Mouse wheel down
-			parts -= 1
-			if parts < 1:
-				parts = 1
-			set_property("parts", parts, true)
-		elif event.button_index == 4: # Mouse wheel up
-			parts += 1
-			set_property("parts", parts, true)
+	parts_input_handler(event,self)
 
 func _process(_delta):
 	if parts != last_parts:

--- a/scenes/actors/objects/wood_platform/wood_platform.gd
+++ b/scenes/actors/objects/wood_platform/wood_platform.gd
@@ -18,15 +18,7 @@ func _set_property_values():
 	set_property("color", color, 1)
 
 func _input(event):
-	if event is InputEventMouseButton and event.is_pressed() and hovered:
-		if event.button_index == 5: # Mouse wheel down
-			parts -= 1
-			if parts < 1:
-				parts = 1
-			set_property("parts", parts, true)
-		elif event.button_index == 4: # Mouse wheel up
-			parts += 1
-			set_property("parts", parts, true)
+	parts_input_handler(event,self)
 
 func _process(_delta):
 	if palette != 0:

--- a/scenes/actors/objects/zoom_trigger/zoom_trigger.gd
+++ b/scenes/actors/objects/zoom_trigger/zoom_trigger.gd
@@ -19,18 +19,8 @@ func _set_property_values():
 	set_property("parts", parts)
 	
 func _input(event):
-	if event is InputEventMouseButton and event.is_pressed() and hovered:
-		if event.button_index == 5: # Mouse wheel down
-			parts -= 1
-			if parts < 1:
-				parts = 1
-			set_property("parts", parts, true)
-			update_parts()
-		elif event.button_index == 4: # Mouse wheel up
-			parts += 1
-			set_property("parts", parts, true)
-			update_parts()
-			
+	parts_input_handler(event,self)
+
 func update_parts():
 	sprite.rect_size.y = parts * 32
 	sprite.rect_position.y = (-16 * parts)

--- a/scenes/editor/Bottom.gd
+++ b/scenes/editor/Bottom.gd
@@ -1,0 +1,3 @@
+extends TextureRect
+
+var hovered: bool = false

--- a/scenes/editor/item_picker.gd
+++ b/scenes/editor/item_picker.gd
@@ -87,3 +87,29 @@ func change_group():
 		var item_dragger_node = load(item_dragger_path).instance()
 		item_dragger_node.item = item
 		grid_container.add_child(item_dragger_node)
+	
+	for child in get_children():
+		
+		child.connect("mouse_entered",self,"_on_mouse_entered")
+		child.connect("mouse_exited",self,"_on_mouse_exited")
+	
+	var grid1: GridContainer = get_node("ScrollContainer/GridContainer")
+	var grid2: GridContainer = get_node("Groups/GridContainer")
+	
+	for child in grid1.get_children():
+		
+		child.connect("mouse_entered",self,"_on_mouse_entered")
+		child.connect("mouse_exited",self,"_on_mouse_exited")
+	
+	for child in grid2.get_children():
+		
+		child.connect("mouse_entered",self,"_on_mouse_entered")
+		child.connect("mouse_exited",self,"_on_mouse_exited")
+
+
+func _on_mouse_entered():
+	hovered = true
+
+
+func _on_mouse_exited():
+	hovered = false

--- a/scenes/editor/placeable_items_container.gd
+++ b/scenes/editor/placeable_items_container.gd
@@ -9,6 +9,8 @@ export var selected_color : Color
 export var editor_node_path : NodePath 
 onready var editor_node = get_node(editor_node_path)
 
+var hovered: bool = false
+
 func _ready():
 	var placeable_items = editor_node.get_node(editor_node.placeable_items_path)
 	var starting_toolbar = Singleton.CurrentLevelData.level_data.layout_ids
@@ -32,4 +34,28 @@ func _ready():
 		if index == Singleton.EditorSavedSettings.selected_box:
 			editor_node.selected_box = placeable_item_button
 		add_child(placeable_item_button)
+	
+	for child in get_children():
 		
+		child.connect("mouse_entered",self,"_on_mouse_entered")
+		child.connect("mouse_exited",self,"_on_mouse_exited")
+	
+	var parent: CanvasLayer = get_parent()
+	var level_settings_button: TextureButton = parent.get_node("LevelSettingsButton")
+	var help_button: TextureButton = parent.get_node("HelpButton")
+	var search_button: TextureButton = parent.get_node("SearchButton")
+	var save_button: TextureButton = parent.get_node("SaveButton")
+	var button_children: Array = [level_settings_button,help_button,search_button,save_button]
+	
+	for button in button_children:
+		
+		button.connect("mouse_entered",self,"_on_mouse_entered")
+		button.connect("mouse_exited",self,"_on_mouse_exited")
+
+
+
+func _on_mouse_entered():
+	hovered = true
+
+func _on_mouse_exited():
+	hovered = false

--- a/scenes/editor/quit_wo_saving_window.gd
+++ b/scenes/editor/quit_wo_saving_window.gd
@@ -4,6 +4,7 @@ onready var ok_button = $HBoxContainer/OkButton
 onready var cancel_button = $HBoxContainer/CancelButton
 
 var open_window: EditorWindow setget set_open_window
+var hovered: bool = false
 
 signal confirmed
 
@@ -15,6 +16,47 @@ func _ready():
 	var _connect
 	ok_button.connect("pressed", self, "on_ok_pressed")
 	cancel_button.connect("pressed", self, "on_cancel_pressed")
+	
+	connect("mouse_entered",self,"on_mouse_entered")
+	connect("mouse_exited",self,"on_mouse_exited")
+	
+	var current_parents = [self]
+	var current_children: Array
+	
+	while (array_has_children(current_parents)):
+		
+		current_children = get_array_children(current_parents)
+		
+		for child in current_children:
+			
+			if (child.has_signal("mouse_entered")):
+			
+				child.connect("mouse_entered",self,"on_mouse_entered")
+				child.connect("mouse_exited",self,"on_mouse_exited")
+		
+		current_parents = Array(current_children)
+
+func array_has_children(array:Array)-> bool:
+	
+	for val in array:
+		
+		if (val.get_child_count() != 0):
+			return true
+	
+	return false
+
+func get_array_children(array:Array)-> Array:
+	
+	var children: Array = []
+	
+	for val in array:
+		
+		if (val.get_child_count() == 0):
+			continue
+		
+		children += val.get_children()
+	
+	return children
 
 func on_ok_pressed():
 	emit_signal("confirmed")
@@ -24,3 +66,9 @@ func on_cancel_pressed():
 	
 	if (open_window != null):
 		open_window.open()
+
+func on_mouse_entered()-> void:
+	hovered = true
+
+func on_mouse_exited()-> void:
+	hovered = false

--- a/scenes/editor/window.gd
+++ b/scenes/editor/window.gd
@@ -47,7 +47,8 @@ func open():
 		Singleton2.disable_hotkeys = true
 	
 	var back_button = get_parent().get_node("BackButton")
-	back_button.connect("open_quit_wo_saving_popup",self,"temporary_close")
+	if (!back_button.is_connected("open_quit_wo_saving_popup",self,"temporary_close")):
+		back_button.connect("open_quit_wo_saving_popup",self,"temporary_close")
 	
 	var quit_wo_saving_window = back_button.get_node("QuitWOSavingWindow")
 	quit_wo_saving_window.set_open_window(self)

--- a/scenes/editor/window.gd
+++ b/scenes/editor/window.gd
@@ -24,6 +24,7 @@ onready var click_sound = $CloseButton/ClickSound
 
 onready var tween = $Tween
 var drag_position = null
+var hovered: bool = false
 
 func _gui_input(event):
 	if event is InputEventMouseButton:
@@ -52,6 +53,47 @@ func open():
 	
 	var quit_wo_saving_window = back_button.get_node("QuitWOSavingWindow")
 	quit_wo_saving_window.set_open_window(self)
+	
+	connect("mouse_entered",self,"on_mouse_entered")
+	connect("mouse_exited",self,"on_mouse_exited")
+	
+	var current_parents = [self]
+	var current_children: Array
+	
+	while (array_has_children(current_parents)):
+		
+		current_children = get_array_children(current_parents)
+		
+		for child in current_children:
+			
+			if (child.has_signal("mouse_entered")):
+			
+				child.connect("mouse_entered",self,"on_mouse_entered")
+				child.connect("mouse_exited",self,"on_mouse_exited")
+		
+		current_parents = Array(current_children)
+
+func array_has_children(array:Array)-> bool:
+	
+	for val in array:
+		
+		if (val.get_child_count() != 0):
+			return true
+	
+	return false
+
+func get_array_children(array:Array)-> Array:
+	
+	var children: Array = []
+	
+	for val in array:
+		
+		if (val.get_child_count() == 0):
+			continue
+		
+		children += val.get_children()
+	
+	return children
 
 func temporary_close()-> void:
 	if visible:
@@ -87,3 +129,9 @@ func pressed():
 	
 func is_open() -> bool:
 	return visible
+
+func on_mouse_entered()-> void:
+	hovered = true
+
+func on_mouse_exited()-> void:
+	hovered = false

--- a/scenes/shared/button_sound_player.gd
+++ b/scenes/shared/button_sound_player.gd
@@ -4,6 +4,7 @@ onready var hover_sound = $HoverSound
 onready var click_sound = $ClickSound
 
 var last_hovered
+var hovered: bool = false
 
 func _pressed():
 	click_sound.play()


### PR DESCRIPTION
Objects that can change their parts by scrolling now check if the mouse is hovered over something (any of the editor windows and certain parts of the screen)
If the check succeeds (something other than the object is hovered) the parts property cannot be changed while scrolling the mouse wheel