### PR TITLE
Invalid levels no longer crash the game

### DIFF
--- a/classes/GameObject.gd
+++ b/classes/GameObject.gd
@@ -173,8 +173,9 @@ func has_editor_alias(key):
 
 
 func set_property_by_index(index, value, change_level_object, alias = null):
-	var key = (base_savable_properties + savable_properties)[index]
-	set_property(key, value, change_level_object, alias)
+	if (index < (base_savable_properties + savable_properties).size()):
+		var key = (base_savable_properties + savable_properties)[index]
+		set_property(key, value, change_level_object, alias)
 
 
 func _set_properties():

--- a/classes/LevelInfo.gd
+++ b/classes/LevelInfo.gd
@@ -73,11 +73,23 @@ func _init(passed_id: String, passed_folder: String, passed_level_code: String =
 		return
 	
 	var info_level_code: String = get_info_level_code(passed_level_code)
+	if (info_level_code == null):
+		return
 	var result: Dictionary = level_code_util.decode_info(info_level_code)
 	
 	level_name = result.get("name", "")
 	level_author = result.get("author", "")
 	level_description = result.get("description", "")
+	
+	if (result.size() < 3):
+		level_name = "~~~"
+		return
+	
+	if (typeof(result.areas[0].settings.sky) != TYPE_INT or
+	typeof(result.areas[0].settings.background) != TYPE_INT or
+	typeof(result.areas[0].settings.background_palette) != TYPE_INT):
+		level_name = "~~~"
+		return
 	
 	thumbnail_url = result.get("thumbnail_url", "")
 	thumbnail_sky = result.areas[0].settings.sky
@@ -90,10 +102,17 @@ func load_in() -> void:
 	
 	level_data = LevelData.new(level_code)
 	
+	if (thumbnail_sky == -999):
+		return
+	
 	level_name = level_data.name
 	level_author = level_data.author
 	level_description = level_data.description
 	thumbnail_url = level_data.thumbnail_url
+	
+	if (level_data.areas.size() == 0):
+		thumbnail_sky = -999
+		return
 	
 	thumbnail_sky = level_data.areas[0].settings.sky
 	thumbnail_background = level_data.areas[0].settings.background

--- a/level/Data.gd
+++ b/level/Data.gd
@@ -77,6 +77,8 @@ func _init(code: String = ""):
 #	functions.size_process_function = process_function_struct
 
 func get_vector2(result) -> Vector2:
+	if (typeof(result) != TYPE_VECTOR2):
+		return Vector2(24,14)
 	return Vector2(result.x, result.y)
 
 func get_area(result) -> LevelArea:
@@ -214,6 +216,9 @@ func load_in(code):
 
 	var result
 	result = level_code_util.decode(code)
+	
+	if (result == null or result.size() < 5):
+		return
 
 	if result.format_version == "0.4.0":
 		result = conversion_util.convert_040_to_041(result)
@@ -259,11 +264,14 @@ func load_in(code):
 		result = conversion_util.convert_052_to_053(result)
 
 	assert(result.format_version)
+	var version_int = result.format_version.replace(".","")
 	var format_version = result.format_version
 	name = result.name
-	author = result.author
-	description = result.description
-	thumbnail_url = result.thumbnail_url
+	
+	if (version_int.is_valid_integer()):
+		author = result.author
+		description = result.description
+		thumbnail_url = result.thumbnail_url
 	
 	layout_ids = result.layout_ids
 	layout_palettes = result.layout_palettes

--- a/scenes/editor/background_changer.gd
+++ b/scenes/editor/background_changer.gd
@@ -23,7 +23,12 @@ func update_preview():
 	var data = Singleton.CurrentLevelData.level_data
 	var area = data.areas[Singleton.CurrentLevelData.area]
 	var palette = area.settings.background_palette
-
+	
+	if (abs(area.settings.sky) > background_id_mapper.ids.size()-1):
+		area.settings.sky = 0
+	if (abs(area.settings.background) > foreground_id_mapper.ids.size()-1):
+		area.settings.background = 0
+	
 	var background_mapped_id = background_id_mapper.ids[area.settings.sky]
 	var background_resource = load("res://scenes/shared/background/backgrounds/" + background_mapped_id + "/resource.tres")
 	

--- a/scenes/editor/placeable_items_container.gd
+++ b/scenes/editor/placeable_items_container.gd
@@ -19,7 +19,10 @@ func _ready():
 		var item
 		if index < starting_toolbar.size():
 			item = placeable_items.find_node(starting_toolbar[index])
-			item.update_palette(starting_toolbar_palettes[index])
+			if (is_instance_valid(item)):
+				item.update_palette(starting_toolbar_palettes[index])
+			else:
+				item = placeable_items.find_node("Grass")
 
 		var placeable_item_button = PLACEABLE_ITEM_BUTTON.instance()
 		placeable_item_button.item = item

--- a/scenes/menu/level_portal/http/http_images.gd
+++ b/scenes/menu/level_portal/http/http_images.gd
@@ -60,13 +60,16 @@ func request_completed(result: int, response_code: int, headers: PoolStringArray
 	else:
 		error = image.load_jpg_from_buffer(body)
 	
+	var texture: ImageTexture
+	
 	if error != OK:
 		printerr("Image failed to load.")
 	
-	var texture := ImageTexture.new()
-	texture.create_from_image(image)
-	
-	cached_images[url] = texture
+	else:
+		texture = ImageTexture.new()
+		texture.create_from_image(image)
+		
+		cached_images[url] = texture
 	loading = false
 	emit_signal("image_loaded", url, texture)
 	

--- a/scenes/menu/levels_list/cards/level/decoration.gd
+++ b/scenes/menu/levels_list/cards/level/decoration.gd
@@ -6,6 +6,7 @@ const SHINE_MATERIAL: ShaderMaterial = preload("res://scenes/menu/levels_list/ca
 ## nodes
 onready var level_card: LevelCard = get_owner()
 onready var visibility_enabler_2d := $"%VisibilityEnabler2D"
+onready var default_thumbnail = preload("res://.import/default_thumb.png-3e78509f186eb58e5a939ece4213411a.stex")
 
 onready var panel := $"%Panel"
 onready var thumbnail_edge := $"%Edge"
@@ -26,7 +27,13 @@ func _ready():
 	
 	level_info = level_card.level_info
 	name_label.text = level_info.level_name
-	check_thumbnail()
+	
+	var is_valid: bool = (name_label.text != "~~~")
+	
+	if (!is_valid):
+		thumbnail.texture = default_thumbnail
+	else:
+		check_thumbnail()
 	
 	if level_card.has_save and level_info.is_fully_completed():
 		activate_completion_style()

--- a/scenes/menu/levels_list/cards/level/level_card.gd
+++ b/scenes/menu/levels_list/cards/level/level_card.gd
@@ -39,10 +39,16 @@ func setup(
 	var file_path: String = level_list_util.get_level_file_path(id, parent_folder)
 	if level_code == "":
 		level_code = level_list_util.load_level_code_file(file_path)
-	elif not level_code_util.fast_is_valid(level_code):
-		level_code = level_list_util.load_level_code_file(LevelData.DEFAULT_CODE_PATH)
+#	elif not level_code_util.fast_is_valid(level_code):
+#		level_code = level_list_util.load_level_code_file(LevelData.DEFAULT_CODE_PATH)
 	
 	level_info = LevelInfo.new(id, parent_folder, level_code)
+	
+	# Uncomment the lines below and above to have any invalid level code be replaced by the default level code
+	# For now it just shows a predefined invalid level card that doesn't let you edit or play the level
+#	if (level_info.level_name == "~~~"):
+#		level_code = level_list_util.load_level_code_file(LevelData.DEFAULT_CODE_PATH)
+#		level_info = LevelInfo.new(id, parent_folder, level_code)
 	
 	# load save file
 	var save_path: String = level_list_util.get_level_save_path(id, parent_folder)

--- a/scenes/menu/levels_list/level_panel/level_panel.gd
+++ b/scenes/menu/levels_list/level_panel/level_panel.gd
@@ -92,6 +92,7 @@ func load_level_info(_level_info: LevelInfo, _level_id: String, _working_folder:
 		foreground.visible = false
 		thumbnail.texture = default_thumbnail
 		
+		load_time_scores()
 		load_collectibles_info(level_info)
 		
 		return

--- a/scenes/menu/levels_list/level_panel/level_panel.gd
+++ b/scenes/menu/levels_list/level_panel/level_panel.gd
@@ -5,6 +5,7 @@ const TIME_SCORE_SCENE: PackedScene = preload("res://scenes/menu/levels_list/lev
 
 onready var list_handler = $"%ListHandler"
 onready var http_thumbnails = $"%HTTPThumbnails"
+onready var default_thumbnail = preload("res://.import/default_thumb.png-3e78509f186eb58e5a939ece4213411a.stex")
 
 var working_folder: String
 var level_id: String
@@ -44,11 +45,27 @@ onready var percentage_label := $InfoTab/Info/Completion/Percentage
 onready var time_scores_container: VBoxContainer = $ScoresTab/Panel/ScrollContainer/MarginContainer/VBoxContainer
 
 ### buttons
+onready var play_button = $Buttons/PlayLevel
 onready var back_button = $Buttons/Return
 onready var edit_button = $Buttons/EditLevel
 onready var reset_button = $Buttons/ResetSave
 onready var delete_button = $Buttons/DeleteLevel
 
+func load_collectibles_info(level_info: LevelInfo)-> void:
+	
+	var collectible_counts = level_info.get_collectible_counts()
+	
+	var total_shine_count: int = collectible_counts["total_shines"]
+	var collected_shine_count: int = collectible_counts["collected_shines"]
+	
+	shine_label.text = str(collected_shine_count) + "/" + str(total_shine_count)
+	shine_label.modulate = completion_color if (collected_shine_count >= total_shine_count) else Color.white
+	
+	var total_star_coin_count: int = collectible_counts["total_star_coins"]
+	var collected_star_coin_count: int = collectible_counts["collected_star_coins"]
+	
+	star_coin_label.text = str(collected_star_coin_count) + "/" + str(total_star_coin_count)
+	star_coin_label.modulate = completion_color if (collected_star_coin_count >= total_star_coin_count) else Color.white
 
 func load_level_info(_level_info: LevelInfo, _level_id: String, _working_folder: String, _can_edit: bool = true):
 	yield(get_parent(), "screen_opened")
@@ -60,6 +77,26 @@ func load_level_info(_level_info: LevelInfo, _level_id: String, _working_folder:
 	
 	# load the real level data now
 	level_info.load_in()
+	
+	if (level_info.thumbnail_sky == -999):
+		# Invalid level detected!
+		edit_button.visible = false
+		play_button.visible = false
+		title.text = "Invalid Level"
+		title_shadow.text = title.text
+		author.text = "Unauthored"
+		description.bbcode_text = "[center]" + "The are no descriptions for invalid levels, silly :)" + "[/center]"
+		back_button.focus_neighbour_top = back_button.get_path_to(reset_button)
+		reset_button.focus_neighbour_bottom = reset_button.get_path_to(back_button)
+		
+		foreground.visible = false
+		thumbnail.texture = default_thumbnail
+		
+		load_collectibles_info(level_info)
+		
+		return
+	
+	play_button.visible = true
 	
 	title.text = level_info.level_name
 	title_shadow.text = title.text
@@ -101,25 +138,13 @@ func load_level_info(_level_info: LevelInfo, _level_id: String, _working_folder:
 		level_info.load_save_from_dictionary(level_list_util.load_level_save_file(save_path))
 	load_time_scores()
 	
+	load_collectibles_info(level_info)
 	var collectible_counts = level_info.get_collectible_counts()
-	
-	var total_shine_count: int = collectible_counts["total_shines"]
-	var collected_shine_count: int = collectible_counts["collected_shines"]
-	
-	shine_label.text = str(collected_shine_count) + "/" + str(total_shine_count)
-	shine_label.modulate = completion_color if (collected_shine_count >= total_shine_count) else Color.white
-	
-	var total_star_coin_count: int = collectible_counts["total_star_coins"]
-	var collected_star_coin_count: int = collectible_counts["collected_star_coins"]
-	
-	star_coin_label.text = str(collected_star_coin_count) + "/" + str(total_star_coin_count)
-	star_coin_label.modulate = completion_color if (collected_star_coin_count >= total_star_coin_count) else Color.white
-	
 	
 	# these are floats cuz they need to be divided for some calculations :)
 	var total_collectibles: float = collectible_counts["total_collectibles"]
 	var total_collected: float = collectible_counts["total_collected"]
-	if total_collectibles <= 0: 
+	if total_collectibles <= 0:
 		percentage_label.text = "100%"
 		percentage_label.modulate = completion_color
 		return # OTHERWISE THE UNIVERSE WILL EXPLODEEEE ZOMG

--- a/scenes/shared/level_data.gd
+++ b/scenes/shared/level_data.gd
@@ -31,7 +31,8 @@ func pick_random_music() -> void:
 	var rng := RandomNumberGenerator.new()
 	rng.randomize()
 	var array_index = rng.randi_range(0, random_music.size() - 1)
-	level_data.areas[area].settings.music = random_music[array_index]
+	if (level_data.areas.size() > 0):
+		level_data.areas[area].settings.music = random_music[array_index]
 
 func create_level_data():
 	level_data = LevelData.new()
@@ -57,7 +58,7 @@ func get_cached_object(index: int):
 	return object_cache[index]
 
 func get_cached_background(index: int):
-	if background_cache.size() <= index: 
+	if background_cache.size() <= index or abs(index) > background_cache.size()-1:
 		index = 0
 	if background_cache[index] != null:
 		return background_cache[index]
@@ -69,7 +70,7 @@ func get_cached_background(index: int):
 	return background_cache[index]
 
 func get_cached_foreground(index: int):
-	if foreground_cache.size() <= index: 
+	if foreground_cache.size() <= index or abs(index) > foreground_cache.size()-1:
 		index = 0
 	if foreground_cache[index] != null:
 		return foreground_cache[index]

--- a/util/conversion_util.gd
+++ b/util/conversion_util.gd
@@ -212,7 +212,9 @@ static func convert_052_to_053(result):
 static func compareVersions(version, other) -> int:
 	var v = version.split(".")
 	var o = other.split(".")
-
+	
+	if (len(v) != 3 or len(o) != 3):
+		return -1
 	for i in range(3):
 		var nv = int(v[i])
 		var no = int(o[i])

--- a/util/level_code_util.gd
+++ b/util/level_code_util.gd
@@ -279,6 +279,7 @@ static func decode_info(code: String) -> Dictionary:
 		add_amount = 4
 	
 	if (code_array.size() < 5 + add_amount):
+		result.name = "~~~"
 		return result
 	
 	var area_index: int = 2 + add_amount

--- a/util/level_code_util.gd
+++ b/util/level_code_util.gd
@@ -112,6 +112,10 @@ static func decode(code: String) -> Dictionary:
 	code = code.replace("\n", "")
 	var code_array = split_code_top_level(code)
 	
+	if (code_array.size() < 4):
+		result.areas = [{}]
+		return result
+	
 	result.format_version = code_array[0]
 	result.name = code_array[1].percent_decode()
 	
@@ -180,6 +184,11 @@ static func decode(code: String) -> Dictionary:
 		var area_array = code_array[area_index].split("~")
 	
 		var area_settings_array = area_array[0].split(",")
+		
+		if (area_settings_array.size() < 4):
+			result.areas = [{}]
+			return result
+		
 		result.areas.append({})
 		result.areas[area_id].settings = {}
 		result.areas[area_id].settings.size = value_util.decode_value(area_settings_array[0])
@@ -256,7 +265,7 @@ static func decode_info(code: String) -> Dictionary:
 	var code_array: Array = code.split(",")
 	
 	result.format_version = code_array[0]
-	result.name = code_array[1].percent_decode()
+	result.name = code_array[1].percent_decode() if code_array.size() > 1 else "~~~"
 	
 	
 	var add_amount = 1
@@ -268,6 +277,9 @@ static func decode_info(code: String) -> Dictionary:
 		result.description = code_array[3].percent_decode()
 		result.thumbnail_url = code_array[4].percent_decode()
 		add_amount = 4
+	
+	if (code_array.size() < 5 + add_amount):
+		return result
 	
 	var area_index: int = 2 + add_amount
 	result.areas = [{}]

--- a/util/new/levels_list/level_list_util.gd
+++ b/util/new/levels_list/level_list_util.gd
@@ -270,11 +270,12 @@ static func get_level_thumbnail_path(level_id: String, working_folder: String, a
 static func get_image_from_path(file_path: String) -> ImageTexture:
 	var image := Image.new()
 	var err: int = image.load(file_path)
+	var texture := ImageTexture.new()
 	if err != OK:
 		printerr("Error loading image at path " + file_path + ". Error code: " + str(err))
-	 
-	var texture := ImageTexture.new()
-	texture.create_from_image(image)
+	
+	else:
+		texture.create_from_image(image)
 	return texture
 
 


### PR DESCRIPTION
Invalid levels can still be loaded into the level list, but can't be played or edited (you can still copy their codes though)
Invalid levels use the default thumbnail and some predefined level info to differentiate them from valid levels