### PR TITLE
Reading text pauses area timers

### DIFF
--- a/classes/GameObject.gd
+++ b/classes/GameObject.gd
@@ -61,8 +61,6 @@ func _ready():
 		color.a = 0.5
 		modulate = color
 	
-	print("From object, ", level_object)
-	
 	if layer != default_layer and lock_layer:
 		set_property("layer", default_layer, true)
 	

--- a/classes/text/dialogue.gd
+++ b/classes/text/dialogue.gd
@@ -149,6 +149,7 @@ func open_menu(new_char: Character):
 	var players: Array = get_tree().root.get_node("Player").get_characters()
 	for player in players:
 		setup_char(player)
+		player.reading_text = true
 
 
 func menu_closed():
@@ -157,6 +158,7 @@ func menu_closed():
 	for player in players:
 		if is_instance_valid(player) and not player.controllable:
 			restore_control(player)
+			player.reading_text = false
 	reset_read_timer = 0.5
 	has_been_read = true
 	page_cache = 0

--- a/scenes/actors/mario/mario.gd
+++ b/scenes/actors/mario/mario.gd
@@ -162,6 +162,7 @@ var last_state : State = null
 var switching_state := false
 export var controllable := true
 export var shine_cutscene: bool = false
+export var reading_text: bool = false
 export var auto_flip := true
 export var invulnerable := false
 export var invulnerable_frames := 0

--- a/scenes/player/ui_new/text/dialogue_text.gd
+++ b/scenes/player/ui_new/text/dialogue_text.gd
@@ -52,7 +52,7 @@ func _ready():
 func open(_dialogue : PoolStringArray, dialogue_node : Node2D, character_node : Character, character_name : String):
 	Singleton.CurrentLevelData.can_pause = false
 	
-	var area_timer : TimerBase = get_tree().get_current_scene().get_node("%TimerManager").pause_resume_timer("area_timer", true)
+#	get_tree().get_current_scene().get_node("%TimerManager").pause_resume_timer("area_timer", true)
 	
 	dialogue = _dialogue
 	character = character_node

--- a/scenes/player/ui_new/text/sign_text.gd
+++ b/scenes/player/ui_new/text/sign_text.gd
@@ -29,6 +29,10 @@ func open(text : String, sign_node : Node2D, character_node : Character):
 	label.bbcode_text = "[center]" + text_replace_util.parse_text(text, character) + "[/center]"
 	close_label.bbcode_text = text_replace_util.parse_text("[center]Press :interactinput: to close[/center]", character_node)
 	open = true
+	
+	var players: Array = get_tree().root.get_node("Player").get_characters()
+	for player in players:
+		player.reading_text = true
 
 func close():
 	Singleton.CurrentLevelData.can_pause = true
@@ -39,6 +43,10 @@ func close():
 	menu_close.play()
 	character = null
 	sign_obj = null
+	
+	var players: Array = get_tree().root.get_node("Player").get_characters()
+	for player in players:
+		player.reading_text = false
 	
 func _physics_process(delta):
 	if !open:

--- a/scenes/player/ui_new/timers/timer.gd
+++ b/scenes/player/ui_new/timers/timer.gd
@@ -62,6 +62,11 @@ func _physics_process(delta):
 	if not is_counting and time > 0 && !player.shine_cutscene:
 		cancel_time_over()
 	
+	if (player.reading_text):
+		is_counting = false
+	else:
+		is_counting = true
+	
 	if is_counting:
 		death_sound_timer.paused = false
 		time -= fps_util.PHYSICS_DELTA

--- a/scenes/shared/objects.gd
+++ b/scenes/shared/objects.gd
@@ -43,8 +43,6 @@ func create_object(object, add_to_data):
 		object_node.shared = get_node(shared_path)
 		object_node.palette = object.palette
 		
-		print(object_node.level_object)
-		
 		if not add_to_data:
 			if object_node.layer != object_node.default_layer:
 				object_node.layer


### PR DESCRIPTION
While reading text from dialogue or signs area timers will be paused and no longer kill the player