### PR TITLE
Fix ObjectData references

### DIFF
--- a/level/Area.gd
+++ b/level/Area.gd
@@ -34,7 +34,7 @@ export var underwater_music: String = ""
 func duplicate_objects(base_objects: Array):
 	var new_objects: Array
 	for object in base_objects:
-		var new_object = ObjectData.new()
+		var new_object = ObjectDataOld.new()
 		new_object.type_id = object.type_id
 		new_object.palette = object.palette
 		for prop in object.properties:

--- a/level/Data.gd
+++ b/level/Data.gd
@@ -185,9 +185,9 @@ func get_chunk_for_position(x: int, y: int, layer: int, chunks: Dictionary) -> A
 		return chunk
 
 
-func get_object(result) -> ObjectData:
+func get_object(result) -> ObjectDataOld:
 	var object
-	object = ObjectData.new()
+	object = ObjectDataOld.new()
 	object.type_id = result.type_id
 	object.palette = result.palette
 	object.properties = result.properties

--- a/level/ObjectDataOld.gd
+++ b/level/ObjectDataOld.gd
@@ -1,0 +1,7 @@
+class_name ObjectDataOld
+extends Resource
+
+var type_id: int = 0
+var palette: int = 0
+
+var properties: Array = []

--- a/scenes/actors/objects/big_steely/big_steely.gd
+++ b/scenes/actors/objects/big_steely/big_steely.gd
@@ -72,7 +72,7 @@ func destroy():
 func create_coin(): #creates a coin
 	time_alive += 1
 	time_alive += (time_alive/3*5/10)
-	var object = ObjectData.new()
+	var object = ObjectDataOld.new()
 	object.type_id = 40
 	object.properties = []
 	object.properties.append(body.global_position)

--- a/scenes/actors/objects/big_steely_entrance/big_steely_entrance.gd
+++ b/scenes/actors/objects/big_steely_entrance/big_steely_entrance.gd
@@ -46,7 +46,7 @@ func check_for_blocking_elements() -> bool:
 	return get_world_2d().direct_space_state.intersect_shape(shape_query_parameters).empty()
 
 func create_new_steely_object() -> Node:
-	var object = ObjectData.new()
+	var object = ObjectDataOld.new()
 	object.type_id = 37
 	object.properties = []
 	object.properties.append(global_position)

--- a/scenes/actors/objects/bill_blaster/bill_blaster.gd
+++ b/scenes/actors/objects/bill_blaster/bill_blaster.gd
@@ -82,7 +82,7 @@ func _physics_process(delta):
 			var prev_scale_x = scale.x
 			scale.x = scale.y
 			
-			var object = ObjectData.new()
+			var object = ObjectDataOld.new()
 			object.type_id = 25
 			object.properties = []
 			object.properties.append(transform.xform(Vector2(16 * facing_direction, 0)))

--- a/scenes/actors/objects/blurp/blurp.gd
+++ b/scenes/actors/objects/blurp/blurp.gd
@@ -108,7 +108,7 @@ func steely_hit(hit_pos : Vector2) -> void:
 		kill(hit_pos)
 
 func create_coin() -> void:
-	var object := ObjectData.new()
+	var object := ObjectDataOld.new()
 	object.type_id = 1
 	object.properties = []
 	object.properties.append(kinematic_body.global_position)

--- a/scenes/actors/objects/bob_omb/bob_omb.gd
+++ b/scenes/actors/objects/bob_omb/bob_omb.gd
@@ -59,7 +59,7 @@ func player_entered(body):
 
 
 func create_coin():
-	var object = ObjectData.new()
+	var object = ObjectDataOld.new()
 	object.type_id = 1
 	object.properties = []
 	object.properties.append(kinematic_body.global_position)

--- a/scenes/actors/objects/breakable_block/breakable_block.gd
+++ b/scenes/actors/objects/breakable_block/breakable_block.gd
@@ -126,7 +126,7 @@ func _physics_process(delta):
 func create_coin(): #creates a coin
 	time_alive += 1
 	time_alive += (time_alive/3*5/10)
-	var object = ObjectData.new()
+	var object = ObjectDataOld.new()
 	object.type_id = 1
 	object.properties = []
 	object.properties.append(static_body.global_position)

--- a/scenes/actors/objects/cheep_cheep/cheep_cheep.gd
+++ b/scenes/actors/objects/cheep_cheep/cheep_cheep.gd
@@ -108,7 +108,7 @@ func steely_hit(hit_pos : Vector2) -> void:
 		kill(hit_pos)
 
 func create_coin() -> void:
-	var object := ObjectData.new()
+	var object := ObjectDataOld.new()
 	object.type_id = 1
 	object.properties = []
 	object.properties.append(kinematic_body.global_position)

--- a/scenes/actors/objects/enemy/enemy_base.gd
+++ b/scenes/actors/objects/enemy/enemy_base.gd
@@ -129,7 +129,7 @@ func is_on_ground() -> bool:
 
 
 func create_coin(velocity: Vector2, offset: Vector2) -> GameObject:
-	var object: = ObjectData.new()
+	var object: = ObjectDataOld.new()
 	object.type_id = 1
 	object.properties = []
 	object.properties.append(global_position + offset)

--- a/scenes/actors/objects/hover_box/hover_box.gd
+++ b/scenes/actors/objects/hover_box/hover_box.gd
@@ -61,7 +61,7 @@ func enter_detector(body):
 			body.add_nozzle("HoverNozzle")
 			
 			#create nozzle after bouncing
-			var object = ObjectData.new()
+			var object = ObjectDataOld.new()
 			object.type_id = 20
 			object.properties = []
 			object.properties.append(position + Vector2(0, 4))

--- a/scenes/actors/objects/metal_breakable_block/metal_breakable_block.gd
+++ b/scenes/actors/objects/metal_breakable_block/metal_breakable_block.gd
@@ -116,7 +116,7 @@ func _physics_process(delta):
 func create_coin(): #creates a coin
 	time_alive += 1
 	time_alive += (time_alive/3*5/10)
-	var object = ObjectData.new()
+	var object = ObjectDataOld.new()
 	object.type_id = 1
 	object.properties = []
 	object.properties.append(static_body.global_position)

--- a/scenes/actors/objects/nipper_plant/nipper_plant.gd
+++ b/scenes/actors/objects/nipper_plant/nipper_plant.gd
@@ -113,7 +113,7 @@ func hit(hit_pos: Vector2):
 	position.y -= 2
 
 func create_coin()->void :
-	var object: = ObjectData.new()
+	var object: = ObjectDataOld.new()
 	object.type_id = 1
 	object.properties = []
 	object.properties.append(body.global_position)
@@ -258,7 +258,7 @@ func calculate_fireball_velocity(source_position: Vector2, target_position: Vect
 	return new_velocity/.13
 
 func spawn_fireball():
-	var object: = ObjectData.new()
+	var object: = ObjectDataOld.new()
 					
 	object.type_id = 134
 	object.properties = []

--- a/scenes/actors/objects/old_goomba/goomba.gd
+++ b/scenes/actors/objects/old_goomba/goomba.gd
@@ -115,7 +115,7 @@ func steely_hit(hit_pos:Vector2)->void :
 		kill(hit_pos)
 
 func create_coin()->void :
-	var object: = ObjectData.new()
+	var object: = ObjectDataOld.new()
 	object.type_id = 1
 	object.properties = []
 	object.properties.append(kinematic_body.global_position)

--- a/scenes/actors/objects/rainbow_breakable_block/rainbow_breakable_block.gd
+++ b/scenes/actors/objects/rainbow_breakable_block/rainbow_breakable_block.gd
@@ -99,7 +99,7 @@ func _physics_process(delta):
 func create_coin(): #creates a coin
 	time_alive += 1
 	time_alive += (time_alive/3*5/10)
-	var object = ObjectData.new()
+	var object = ObjectDataOld.new()
 	object.type_id = 1
 	object.properties = []
 	object.properties.append(static_body.global_position)

--- a/scenes/actors/objects/rex/rex.gd
+++ b/scenes/actors/objects/rex/rex.gd
@@ -128,7 +128,7 @@ func steely_hit(hit_pos:Vector2)->void :
 		kill(hit_pos)
 
 func create_coin() -> void:
-	var object: = ObjectData.new()
+	var object: = ObjectDataOld.new()
 	object.type_id = 1
 	object.properties = []
 	object.properties.append(kinematic_body.global_position)

--- a/scenes/actors/objects/rocket_box/rocket_box.gd
+++ b/scenes/actors/objects/rocket_box/rocket_box.gd
@@ -63,7 +63,7 @@ func enter_detector(body):
 			body.add_nozzle("RocketNozzle")
 			
 			#create nozzle after bouncing
-			var object = ObjectData.new()
+			var object = ObjectDataOld.new()
 			object.type_id = 20
 			object.properties = []
 			object.properties.append(position + Vector2(0, 4))

--- a/scenes/actors/objects/skeleton_goonie/skeleton_goonie.gd
+++ b/scenes/actors/objects/skeleton_goonie/skeleton_goonie.gd
@@ -95,7 +95,7 @@ func exploded(hit_pos:Vector2):
 	hurt(hit_pos)
 
 func create_coin(spawn_pos) -> void:
-	var object: = ObjectData.new()
+	var object: = ObjectDataOld.new()
 	object.type_id = 1
 	object.properties = []
 	object.properties.append(spawn_pos)

--- a/scenes/actors/objects/turbo_box/turbo_box.gd
+++ b/scenes/actors/objects/turbo_box/turbo_box.gd
@@ -62,7 +62,7 @@ func enter_detector(body):
 			body.add_nozzle("TurboNozzle")
 			
 			#create nozzle after bouncing
-			var object = ObjectData.new()
+			var object = ObjectDataOld.new()
 			object.type_id = 20
 			object.properties = []
 			object.properties.append(position + Vector2(0, 4))

--- a/scenes/editor/action_manager/actions/base_object.gd
+++ b/scenes/editor/action_manager/actions/base_object.gd
@@ -4,7 +4,7 @@ extends Action
 
 var shared: LevelShared
 var object: GameObject
-var object_data: ObjectData
+var object_data: ObjectDataOld
 var object_index: int
 
 

--- a/scenes/editor/editor_camera.gd
+++ b/scenes/editor/editor_camera.gd
@@ -42,7 +42,7 @@ func _physics_process(delta):
 
 func load_in(_level_data: LevelDataOld, level_area: LevelAreaOld):
 #	for object in level_area.objects:
-#		if is_instance_valid(object) and object is ObjectData:
+#		if is_instance_valid(object) and object is ObjectDataOld:
 #			if object.type_id == 0:
 #				position = object.properties[0] # properties[0] is always position, at least for spawners
 	

--- a/scenes/editor/paint_tool.gd
+++ b/scenes/editor/paint_tool.gd
@@ -116,8 +116,8 @@ func place_object(pos: Vector2):
 #			break
 
 
-func create_object_data(position: Vector2, object_id: int, palette: int) -> ObjectData:
-	var data = ObjectData.new()
+func create_object_data(position: Vector2, object_id: int, palette: int) -> ObjectDataOld:
+	var data = ObjectDataOld.new()
 	data.type_id = object_id
 	data.palette = palette
 	data.properties.append(position)

--- a/scenes/editor/pen_tool.gd
+++ b/scenes/editor/pen_tool.gd
@@ -50,8 +50,8 @@ func place_object(object_item: PlaceableObject):
 			break
 
 
-func create_object_data(position: Vector2, object_id: int, palette: int) -> ObjectData:
-	var data = ObjectData.new()
+func create_object_data(position: Vector2, object_id: int, palette: int) -> ObjectDataOld:
+	var data = ObjectDataOld.new()
 	data.type_id = object_id
 	data.palette = palette
 	data.properties.append(position)

--- a/scenes/editor/tools/obj_paint_tool.gd
+++ b/scenes/editor/tools/obj_paint_tool.gd
@@ -61,8 +61,8 @@ func place_object(pos: Vector2):
 	editor.action_manager.commit_action(action)
 
 
-func create_object_data(position: Vector2, object_id: int, palette: int) -> ObjectData:
-	var data = ObjectData.new()
+func create_object_data(position: Vector2, object_id: int, palette: int) -> ObjectDataOld:
+	var data = ObjectDataOld.new()
 	data.type_id = object_id
 	data.palette = palette
 	data.properties.append(position)

--- a/scenes/editor/tools/path_tool/object_trail.gd
+++ b/scenes/editor/tools/path_tool/object_trail.gd
@@ -43,8 +43,8 @@ func _click_left(_event: InputEvent, _world_pos: Vector2):
 	update_objects_array()
 
 
-func create_object_data(position: Vector2, object_id: int, palette: int) -> ObjectData:
-	var data = ObjectData.new()
+func create_object_data(position: Vector2, object_id: int, palette: int) -> ObjectDataOld:
+	var data = ObjectDataOld.new()
 	data.type_id = object_id
 	data.palette = palette
 	data.properties.append(position)

--- a/scenes/editor/tools/selection_box/selection_box.gd
+++ b/scenes/editor/tools/selection_box/selection_box.gd
@@ -235,7 +235,7 @@ func copy():
 		if editor.selected_objects != {}:
 			var copied_objects: Array
 			for i in editor.selected_objects:
-				var data: ObjectData = i.level_object.get_ref()
+				var data: ObjectDataOld = i.level_object.get_ref()
 				var properties: Array = []
 				for property in data.properties:
 					properties.append(value_util.encode_value(property))
@@ -249,7 +249,7 @@ func generate_object_data():
 	if result is Array:
 		var data_array: Array
 		for i in result:
-			var object_data = ObjectData.new()
+			var object_data = ObjectDataOld.new()
 			var properties: Array = []
 			for property in i["properties"]:
 				properties.append(value_util.decode_value(property))

--- a/scenes/editor/tools/tile_lock_tool.gd
+++ b/scenes/editor/tools/tile_lock_tool.gd
@@ -35,8 +35,8 @@ func _unhandled_input(event):
 				positions.clear()
 	mouse_pos = Vector2(int(get_global_mouse_position().x / 32) * 32, int(get_global_mouse_position().y / 32) * 32) + Vector2(16, 16)
 
-func create_object_data(position: Vector2, object_id: int, palette: int) -> ObjectData:
-	var data = ObjectData.new()
+func create_object_data(position: Vector2, object_id: int, palette: int) -> ObjectDataOld:
+	var data = ObjectDataOld.new()
 	data.type_id = object_id
 	data.palette = palette
 	data.properties.append(position)

--- a/scenes/oldeditor/camera_controls.gd
+++ b/scenes/oldeditor/camera_controls.gd
@@ -37,7 +37,7 @@ func load_in(_level_data: LevelDataOld, level_area: LevelAreaOld):
 	position.x = (get_viewport_rect().size.x / 2) * zoom_level
 	position.y = (level_area.settings.bounds.end.y * 32) - ((get_viewport_rect().size.y / 2) * zoom_level)
 	for object in level_area.objects:
-		if is_instance_valid(object) and object is ObjectData:
+		if is_instance_valid(object) and object is ObjectDataOld:
 			if object.type_id == 0:
 				position = object.properties[0] # properties[0] is always position, at least for spawners
 	

--- a/scenes/oldeditor/editor.gd
+++ b/scenes/oldeditor/editor.gd
@@ -505,8 +505,8 @@ func _process(delta : float) -> void:
 			
 			if left_held and selected_tool == 0 and Input.is_action_just_pressed("place") and !rotating and selected_box.item.is_object:
 				if Input.is_action_pressed("duplicate"):
-					var object := ObjectData.new()
-					var original_object : ObjectData = hovered_object.level_object.get_ref()
+					var object := ObjectDataOld.new()
+					var original_object : ObjectDataOld = hovered_object.level_object.get_ref()
 					object.type_id = original_object.type_id
 					object.palette = original_object.palette
 					for prop in original_object.properties:
@@ -595,7 +595,7 @@ func _process(delta : float) -> void:
 						
 					
 					if object_pos and !shared.is_object_at_position(object_pos) and item.on_place(object_pos, level_data, level_area):
-						var object := ObjectData.new()
+						var object := ObjectDataOld.new()
 						object.type_id = item.object_id
 						object.palette = item.palette_index
 						object.properties.append(object_pos)
@@ -645,7 +645,7 @@ func _process(delta : float) -> void:
 					
 				
 				if object_pos and !shared.is_object_at_position(object_pos) and item.on_place(object_pos, level_data, level_area):
-					var object := ObjectData.new()
+					var object := ObjectDataOld.new()
 					object.type_id = item.object_id
 					object.palette = item.palette_index
 					object.properties.append(object_pos)


### PR DESCRIPTION
This re-adds the old ObjectData class as ObjectDataOld and changes all old implementations to use this class. Eventually everything needs to be ported over to use the new ObjectData, which turns out is quite a bit. But, at least it compiles and getting into the editor is possible. Finding what needs to changed should be easier too since you can distinguish by ObjectData/ObjectDataOld.